### PR TITLE
feat: add compilation errors tool (v2.26.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that gi
 | **Assets** | List, import, delete, search, create prefabs, create & assign materials |
 | **Scripts** | Create, read, update C# scripts |
 | **Builds** | Multi-platform builds (Windows, macOS, Linux, Android, iOS, WebGL) |
-| **Console** | Read/clear Unity console logs (errors, warnings, info) |
+| **Console & Compilation** | Read/clear Unity console logs (errors, warnings, info); get C# compilation errors via CompilationPipeline (independent of console buffer) |
 | **Play Mode** | Play, pause, stop |
 | **Editor** | Execute menu items, run C# code, get editor state, undo/redo |
 | **Project** | Project info, packages (list/add/remove/search), render pipeline, build settings |
@@ -247,6 +247,10 @@ If Unity MCP helps your workflow, consider supporting its development! Your supp
 </a>
 
 **Sponsor tiers include priority feature requests** — your ideas get bumped up the roadmap! Check out the tiers on [GitHub Sponsors](https://github.com/sponsors/AnkleBreaker-Studio) or [Patreon](https://www.patreon.com/AnkleBreakerStudio).
+
+## What's New in v2.26.0
+
+- **Compilation error detection** — New `unity_get_compilation_errors` tool retrieves C# compilation errors and warnings directly from Unity's `CompilationPipeline` API. Unlike `unity_console_log`, this is independent of the console log buffer — not affected by console clear, Play Mode log flooding, or buffer overflow. Supports filtering by severity (`error`, `warning`, `all`) and count limit. Registered as a core tool (always directly accessible, not behind `unity_advanced_tool`).
 
 ## What's New in v2.25.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-mcp-server",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Unity MCP Server — Multi-agent MCP server for Unity Editor, designed for Claude Cowork. By AnkleBreaker Studio.",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ async function ensureInstanceDiscovery() {
 const server = new Server(
   {
     name: "unity-mcp",
-    version: "2.25.0",
+    version: "2.26.0",
   },
   {
     capabilities: {
@@ -516,7 +516,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  debugLog(`=== SERVER START === v2.25.0, agent=${PROCESS_AGENT_ID}, discoveryDone=${_discoveryDonePerAgent.get(PROCESS_AGENT_ID) || false}, selectedPort=${getSelectedInstance()?.port || 'null'}`);
+  debugLog(`=== SERVER START === v2.26.0, agent=${PROCESS_AGENT_ID}, discoveryDone=${_discoveryDonePerAgent.get(PROCESS_AGENT_ID) || false}, selectedPort=${getSelectedInstance()?.port || 'null'}`);
   console.error(
     `Unity MCP Server running on stdio (agent: ${PROCESS_AGENT_ID})`
   );

--- a/src/tool-tiers.js
+++ b/src/tool-tiers.js
@@ -103,9 +103,10 @@ const CORE_TOOLS = new Set([
   "unity_build",
   "unity_play_mode",
 
-  // Console
+  // Console & Compilation
   "unity_console_log",
   "unity_console_clear",
+  "unity_get_compilation_errors",
 
   // Editor actions
   "unity_execute_menu_item",

--- a/src/tools/editor-tools.js
+++ b/src/tools/editor-tools.js
@@ -474,6 +474,25 @@ export const editorTools = [
     handler: async () => JSON.stringify(await bridge.clearConsoleLog(), null, 2),
   },
 
+  // ─── Compilation ───
+  {
+    name: "unity_get_compilation_errors",
+    description:
+      "Get C# compilation errors and warnings from the Unity Editor. " +
+      "Uses CompilationPipeline directly — independent of the console log buffer. " +
+      "Not affected by console clear or Play Mode log flooding. " +
+      "Returns errors from the last compilation cycle. " +
+      "Use this instead of unity_console_log when diagnosing script compilation issues.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        count: { type: "number", description: "Max number of entries to retrieve (default: 50)" },
+        severity: { type: "string", description: "Filter: 'error', 'warning', or 'all' (default: 'all')" },
+      },
+    },
+    handler: async (params) => JSON.stringify(await bridge.getCompilationErrors(params), null, 2),
+  },
+
   // ─── Play Mode ───
   {
     name: "unity_play_mode",

--- a/src/unity-editor-bridge.js
+++ b/src/unity-editor-bridge.js
@@ -530,6 +530,10 @@ export async function clearConsoleLog() {
   return sendCommand("console/clear");
 }
 
+export async function getCompilationErrors(params) {
+  return sendCommand("compilation/errors", params);
+}
+
 export async function playMode(action) {
   return sendCommand("editor/play-mode", { action }); // "play", "pause", "stop"
 }


### PR DESCRIPTION
## Summary

- Add new `unity_get_compilation_errors` tool to retrieve compilation errors/warnings from Unity Editor
- Register the tool in CORE_TOOLS tier for broad availability
- Add bridge route + server-side handler for `/compilation/errors`
- Update README with v2.26.0 section and compilation errors documentation

## Changes (3 commits, 6 files, +33/-5)

- `src/tools/editor-tools.js` — new tool definition and handler
- `src/unity-editor-bridge.js` — bridge route for compilation errors
- `src/index.js` — tool registration
- `src/tool-tiers.js` — add to CORE_TOOLS
- `package.json` — version bump to 2.26.0
- `README.md` — docs update

## Test plan

- [ ] Verify `unity_get_compilation_errors` returns errors when scripts have compilation issues
- [ ] Verify empty response when project compiles cleanly
- [ ] Confirm tool appears in CORE_TOOLS tier
- [ ] Check README renders correctly