### PR TITLE
Add GitHub Action to auto-publish to npm on release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,11 +10,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync package.json version with release tag


### PR DESCRIPTION
## Summary
The npm package `unity-mcp-server` is currently at v1.5.2 while the latest GitHub release is v2.26.0. This adds a GitHub Action that automatically publishes to npm whenever a new GitHub release is created.

## How it works
- Triggered on `release: published` events
- Strips the `v` prefix from the release tag and syncs it into `package.json` via `npm version`
- Runs `npm publish --access public`

## Setup required
1. Create an npm **Automation** token at https://www.npmjs.com/settings/tokens
2. Add it as a repository secret named `NPM_TOKEN` (Settings → Secrets → Actions)

Once set up, every future GitHub release will automatically publish to npm — no manual steps needed. Users can then use `npx unity-mcp-server@latest` to always get the newest version.