### PR TITLE
fix(ci): bump to v2.28.1 — fix npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Sync package.json version with release tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - run: npm install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [2.28.1] - 2026-04-02
+
+### Fixed
+- **npm publish workflow** — Added `--allow-same-version` to `npm version` command to prevent CI failure when `package.json` already matches the release tag
+
 ## [2.28.0] - 2026-04-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anklebreaker-unity-mcp",
-      "version": "2.28.0",
+      "version": "2.28.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Unity MCP Server — Multi-agent MCP server for Unity Editor, designed for Claude Cowork. By AnkleBreaker Studio.",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary

- Fix `npm version` failing when `package.json` already matches the release tag by adding `--allow-same-version`
- Bump version to 2.28.1

## Test plan

- [ ] Create release v2.28.1 and verify npm publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)