### PR TITLE
Release v2.28.2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Sync package.json version with release tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - run: npm install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [2.28.1] - 2026-04-02
+
+### Fixed
+- **npm publish workflow** — Added `--allow-same-version` to `npm version` command to prevent CI failure when `package.json` already matches the release tag
+
 ## [2.28.0] - 2026-04-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [2.28.2] - 2026-04-22
+
+### Fixed
+- **MCP JSON-RPC framing corrupted by debug logs on stdout** — Two `console.debug(...)` call sites in `src/unity-editor-bridge.js` and `src/tool-tiers.js` wrote diagnostic lines to stdout, which the MCP stdio transport reserves exclusively for JSON-RPC messages. Strict clients (Codex CLI) closed the transport on the first non-JSON chunk; lenient clients (Claude Desktop, Claude Code) tolerated it, which is why the bug escaped earlier detection. Both call sites now use `console.error(...)` so logs go to stderr. Fixes [#11](https://github.com/AnkleBreaker-Studio/unity-mcp-server/issues/11).
+
 ## [2.28.1] - 2026-04-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ If Unity MCP helps your workflow, consider supporting its development! Your supp
 
 **Sponsor tiers include priority feature requests** — your ideas get bumped up the roadmap! Check out the tiers on [GitHub Sponsors](https://github.com/sponsors/AnkleBreaker-Studio) or [Patreon](https://www.patreon.com/AnkleBreakerStudio).
 
+## What's New in v2.28.2
+
+- **Codex CLI compatibility** — Two diagnostic `console.debug(...)` calls in the bridge were writing to stdout, corrupting the MCP JSON-RPC framing. Strict clients like Codex CLI closed the transport as soon as they hit the non-JSON line; the bug was invisible on Claude Desktop / Claude Code which tolerate the framing violation. Both call sites now log to stderr.
+
 ## What's New in v2.28.0
 
 - **npm auto-publish** — A GitHub Action now automatically publishes to npm whenever a new GitHub release is created. Contributed by [@vatanaksoytezer](https://github.com/vatanaksoytezer) in [#8](https://github.com/AnkleBreaker-Studio/unity-mcp-server/pull/8).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anklebreaker-unity-mcp",
-      "version": "2.28.0",
+      "version": "2.28.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anklebreaker-unity-mcp",
-      "version": "2.28.1",
+      "version": "2.28.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "description": "Unity MCP Server — Multi-agent MCP server for Unity Editor, designed for Claude Cowork. By AnkleBreaker Studio.",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Unity MCP Server — Multi-agent MCP server for Unity Editor, designed for Claude Cowork. By AnkleBreaker Studio.",
   "type": "module",
   "main": "src/index.js",

--- a/src/tool-tiers.js
+++ b/src/tool-tiers.js
@@ -322,7 +322,8 @@ export function splitToolTiers(allEditorTools) {
       const route = toolNameToRoute(tool);
       if (route) {
         try {
-          console.debug(`[MCP] Lazy-loading tool "${tool}" via route "${route}"`);
+          // Log to stderr, not stdout — stdout carries the MCP JSON-RPC transport.
+          console.error(`[MCP] Lazy-loading tool "${tool}" via route "${route}"`);
           const result = await sendCommand(route, params || {});
           return JSON.stringify(result, null, 2);
         } catch (err) {

--- a/src/unity-editor-bridge.js
+++ b/src/unity-editor-bridge.js
@@ -281,7 +281,9 @@ export async function sendCommand(command, params = {}) {
           const ticketData = await submitToQueue(command, bodyString);
           const ticketId = ticketData.ticketId;
 
-          console.debug(`[MCP Bridge] Submitted ${command} to queue, ticket: ${ticketId}`);
+          // Log to stderr, not stdout — stdout is reserved for the MCP JSON-RPC
+          // transport and any non-JSON data there closes strict clients (e.g. Codex).
+          console.error(`[MCP Bridge] Submitted ${command} to queue, ticket: ${ticketId}`);
 
           // Poll for completion
           const result = await pollQueueStatus(ticketId);


### PR DESCRIPTION
## What's in this release

### Fixed

- **MCP JSON-RPC framing corrupted by debug logs on stdout** — Two `console.debug(...)` call sites in `src/unity-editor-bridge.js` (queue submit log) and `src/tool-tiers.js` (lazy-load log) wrote diagnostic lines to stdout, which the MCP stdio transport reserves exclusively for JSON-RPC messages. Strict clients (Codex CLI) closed the transport on the first non-JSON chunk; lenient clients (Claude Desktop, Claude Code) tolerated it, which is why the bug escaped earlier detection. Both call sites now use `console.error(...)` so logs go to stderr. (Note: four `console.log` calls reported in #1 were already fixed previously; this completes the cleanup by also catching `console.debug`, which Node routes to stdout too.)

## Closes

- #11 (Windows Codex transport closes after successful Unity MCP connect on read-only tool calls)

## Verification

Reproduced the bug against Codex CLI 0.122.0 with the pre-fix server: `unity_list_instances` and `unity_select_instance` succeed, `unity_scene_info` and `unity_editor_state` fail with `Transport closed` (server-only tools don't go through the bridge queue path, so they don't hit the offending log).

After the fix, the exact same Codex command succeeds on all four tools. Regression-checked on Claude (queue mode preserved, all tools still work).

Full audit of `src/` confirms no remaining `console.log`/`console.debug`/`console.info` and no direct `process.stdout.write` outside the MCP SDK.
