### PR TITLE
security: inject X-MCP-Token on all bridge fetch sites

### DIFF
--- a/src/unity-editor-bridge.js
+++ b/src/unity-editor-bridge.js
@@ -1,6 +1,9 @@
 // Unity Editor HTTP Bridge Client
 // Communicates with the C# plugin running inside Unity Editor
 // Supports both queue mode (async ticket-based) and legacy sync mode
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { CONFIG } from "./config.js";
 import { getActiveBridgeUrl } from "./instance-discovery.js";
 
@@ -14,6 +17,37 @@ const BRIDGE_URL = `http://${CONFIG.editorBridgeHost}:${CONFIG.editorBridgePort}
 
 // Agent identity — tracks which AI agent is making requests
 let _currentAgentId = "default";
+
+// X-MCP-Token: shared secret for the editor bridge's opt-in auth gate (added in
+// the D3vCrow security fork of unity-mcp-plugin). The plugin writes the secret
+// to %APPDATA%/unity-mcp/secret on Windows or $XDG_CONFIG_HOME/unity-mcp/secret
+// on Unix. When absent, we send no header and the plugin's EnforceToken=false
+// path accepts the request (upstream behavior).
+//
+// Loaded once at module init. If the operator regenerates the secret in the
+// dashboard, restart the MCP server process to pick up the new value.
+function _loadMcpToken() {
+  const base =
+    process.env.APPDATA ||
+    process.env.XDG_CONFIG_HOME ||
+    join(homedir(), ".config");
+  try {
+    return readFileSync(join(base, "unity-mcp", "secret"), "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+const _mcpToken = _loadMcpToken();
+
+/**
+ * Build request headers including X-Agent-Id and, when available, X-MCP-Token.
+ * @param {object} [extra] - Additional headers to merge (e.g., Content-Type).
+ */
+function authHeaders(extra = {}) {
+  const h = { ...extra, "X-Agent-Id": _currentAgentId };
+  if (_mcpToken) h["X-MCP-Token"] = _mcpToken;
+  return h;
+}
 
 // Mode detection — cached to avoid repeated 404 checks
 let _useQueueMode = true;
@@ -70,10 +104,7 @@ async function submitToQueue(apiPath, bodyString) {
 
   const response = await fetch(url, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Agent-Id": _currentAgentId,
-    },
+    headers: authHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify({
       apiPath,
       method: "POST",
@@ -119,9 +150,7 @@ async function pollQueueStatus(ticketId) {
       const url = `${getBridgeUrl()}/api/queue/status?ticketId=${ticketId}`;
       const response = await fetch(url, {
         method: "GET",
-        headers: {
-          "X-Agent-Id": _currentAgentId,
-        },
+        headers: authHeaders(),
         signal: AbortSignal.timeout(10000), // 10s per individual poll request
       });
 
@@ -193,10 +222,7 @@ async function sendCommandLegacyMode(command, params = {}) {
     try {
       const response = await fetch(url, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Agent-Id": _currentAgentId,
-        },
+        headers: authHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(params),
         signal: controller.signal,
       });
@@ -350,9 +376,7 @@ export async function getQueueInfo() {
     const url = `${getBridgeUrl()}/api/queue/info`;
     const response = await fetch(url, {
       method: "GET",
-      headers: {
-        "X-Agent-Id": _currentAgentId,
-      },
+      headers: authHeaders(),
       signal: AbortSignal.timeout(CONFIG.editorBridgeTimeout),
     });
 
@@ -380,9 +404,7 @@ export async function getTicketStatus(ticketId) {
     const url = `${getBridgeUrl()}/api/queue/status?ticketId=${ticketId}`;
     const response = await fetch(url, {
       method: "GET",
-      headers: {
-        "X-Agent-Id": _currentAgentId,
-      },
+      headers: authHeaders(),
       signal: AbortSignal.timeout(CONFIG.editorBridgeTimeout),
     });
 
@@ -1626,7 +1648,7 @@ export async function getProjectContext(category = null) {
 
   const response = await fetch(url, {
     method: "GET",
-    headers: { "X-Agent-Id": _currentAgentId },
+    headers: authHeaders(),
     signal: AbortSignal.timeout(5000),
   });
 


### PR DESCRIPTION
## Summary
- Load shared secret at module init from `%APPDATA%/unity-mcp/secret` (Windows) or `$XDG_CONFIG_HOME/unity-mcp/secret` (Unix)
- Inject `X-MCP-Token` via new `authHeaders()` helper on all 6 fetch sites in `src/unity-editor-bridge.js` (submitToQueue, pollQueueStatus, sendCommandLegacyMode, getQueueInfo, getTicketStatus, getProjectContext)
- Graceful degradation: if the secret file is absent, no header is sent and existing behavior is preserved — matches the plugin's `EnforceToken=false` default

This is the companion change to the D3vCrow fork of unity-mcp-plugin, which adds an opt-in `X-MCP-Token` gate on mutating verbs (POST/PUT/DELETE). Without a plugin counterpart that enforces the token, this PR is a no-op.

## Test plan
- [x] Positive path: `unity_editor_ping` via MCP → `connected:true`, Unity 6000.3.6f1, project UnityToolkit, processId 23304
- [x] Bad Origin: `curl -X POST -H 'Origin: http://attacker.example.com' ...` → 403 `{"error":"origin not allowed"}`
- [x] Bad token: `curl -X POST -H 'X-MCP-Token: wrong' ...` → 403 `{"error":"token invalid"}`
- [x] Companion auto-connects to port 7891 on session restart; `claude mcp list` shows Connected
- [x] Verified against Unity plugin fork commit `3c2c67a` (thread-safe snapshot) — no 'GetBool can only be called from the main thread' errors

## Caveats
- Token is cached at process start. Regenerating the secret in the plugin dashboard requires restarting the MCP server process.
- No new dependencies — uses Node stdlib (`node:fs`, `node:os`, `node:path`).

Generated with [Claude Code](https://claude.com/claude-code)
