### PR TITLE
[codex] Keep MCP stdout JSON-RPC only

### DIFF
--- a/src/tool-tiers.js
+++ b/src/tool-tiers.js
@@ -322,7 +322,7 @@ export function splitToolTiers(allEditorTools) {
       const route = toolNameToRoute(tool);
       if (route) {
         try {
-          console.debug(`[MCP] Lazy-loading tool "${tool}" via route "${route}"`);
+          console.error(`[MCP] Lazy-loading tool "${tool}" via route "${route}"`);
           const result = await sendCommand(route, params || {});
           return JSON.stringify(result, null, 2);
         } catch (err) {

--- a/src/unity-editor-bridge.js
+++ b/src/unity-editor-bridge.js
@@ -281,7 +281,7 @@ export async function sendCommand(command, params = {}) {
           const ticketData = await submitToQueue(command, bodyString);
           const ticketId = ticketData.ticketId;
 
-          console.debug(`[MCP Bridge] Submitted ${command} to queue, ticket: ${ticketId}`);
+          console.error(`[MCP Bridge] Submitted ${command} to queue, ticket: ${ticketId}`);
 
           // Poll for completion
           const result = await pollQueueStatus(ticketId);


### PR DESCRIPTION
## Summary
- Move MCP bridge queue-submission logging from stdout to stderr.
- Move lazy advanced-tool loading diagnostics from stdout to stderr.

## Root Cause
Codex Desktop treats MCP stdio stdout as strict JSON-RPC. Some Unity MCP tool calls, notably `unity_execute_code`, emitted bridge status text to stdout before the JSON-RPC response, such as:

```text
[MCP Bridge] Submitted editor/execute-code to queue, ticket: ...
```

Clients that ignore non-JSON stdout tolerated this, but Codex closed the transport with `Transport closed`.

## Impact
Keeping stdout reserved for JSON-RPC makes the server compatible with stricter MCP clients while preserving diagnostics on stderr.

## Validation
- Ran a direct stdio smoke test for `unity_execute_code` against Unity 6000.4.2f1.
- Verified `nonJsonStdout: []`.
- Restarted Codex Desktop and verified native MCP calls: `unity_list_instances`, `unity_select_instance`, `unity_editor_ping`, and `unity_execute_code` all succeeded.
