### PR TITLE
AnkleBreaker MCP wins A+F+N: isError flag, tool-tiers echo/did-you-mean, compact JSON default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ import {
 } from "./instance-discovery.js";
 import { debugLog } from "./state-persistence.js";
 import { CONFIG } from "./config.js";
+import { isErrorResult } from "./response-format.js";
 
 // ─── Response size protection ───
 // Prevents "Write EOF" errors when tool responses exceed stdio transport limits.
@@ -439,7 +440,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       contentBlocks.push({ type: "text", text: result });
     }
 
-    return { content: truncateResponseIfNeeded(contentBlocks) };
+    const response = { content: truncateResponseIfNeeded(contentBlocks) };
+    // Surface Unity-side logical errors as MCP errors so the agent can branch
+    // on them (WIN A keystone — the bridge returns HTTP 200 on logical failure).
+    if (isErrorResult(result)) {
+      response.isError = true;
+    }
+    return response;
 
     } finally {
       // Always clear port override after request completes, even on error

--- a/src/response-format.js
+++ b/src/response-format.js
@@ -1,0 +1,67 @@
+// AnkleBreaker Unity MCP — shared response payload formatter (WIN N: compact JSON).
+//
+// Compact JSON by default to save agent tokens (~44% byte reduction measured on
+// nested payloads like deep scene hierarchies — the responses that matter most).
+// The C# bridge (MiniJson) already serializes compact over HTTP; the Node side
+// was re-inflating it with `null, 2` indentation that the model parses identically
+// but pays for in tokens. This reverts that one unnecessary re-pretty step.
+//
+// Set UNITY_MCP_PRETTY_JSON=1 to restore human-readable indentation for debugging.
+
+const PRETTY = process.env.UNITY_MCP_PRETTY_JSON === "1";
+
+/**
+ * Serialize a tool result for the MCP text channel.
+ * Compact by default; indented only when UNITY_MCP_PRETTY_JSON=1.
+ * @param {*} value - the object/array/value to serialize.
+ * @returns {string} JSON string.
+ */
+export function formatResult(value) {
+  return PRETTY ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+}
+
+// ─── Error-flag detection (WIN A keystone) ───
+// The Unity bridge returns HTTP 200 for LOGICAL failures, and tool handlers
+// return one of several error shapes — a `{error: "..."}` object (legacy), a
+// `{success:false}` object, a queue-wrapped `{success:true, data:{error:...}}`,
+// or (with the MCPResponse factory) a `{ok:false, error:{code,message,hint}}`
+// envelope. None set the MCP `isError` flag by themselves, so a client reads a
+// logical failure as success and the agent can't branch on it. These helpers let
+// the Node seam set isError for every existing error shape with ZERO C# edits.
+
+/**
+ * True when a parsed object looks like a logical-error envelope.
+ * A self-declared success (ok:true / success:true) is never treated as an error
+ * even if it carries an `error` key (JsonUtility serializes null strings as "").
+ */
+export function looksLikeErrorObject(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  const claimsSuccess = obj.ok === true || obj.success === true;
+  if (obj.ok === false) return true; // MCPResponse factory envelope
+  if (obj.success === false) return true; // legacy success flag
+  if (obj.error && !claimsSuccess) return true; // legacy {error: msg}
+  if (obj.data && typeof obj.data === "object" && obj.data.error) return true; // queue-wrapped
+  return false;
+}
+
+/**
+ * True when a tool result (string, object, or content-block array) represents a
+ * logical error and the MCP response should carry isError:true.
+ */
+export function isErrorResult(result) {
+  // Content-block arrays (images, screenshots) are always non-error payloads.
+  if (Array.isArray(result)) return false;
+  if (typeof result === "string") {
+    const s = result.trimStart();
+    if (s.startsWith("{") || s.startsWith("[")) {
+      try {
+        return looksLikeErrorObject(JSON.parse(s));
+      } catch {
+        // Not JSON — fall through to the prose check.
+      }
+    }
+    // Plain-string error convention used by the meta-tools (tool-tiers.js).
+    return /^error\b/i.test(s);
+  }
+  return looksLikeErrorObject(result);
+}

--- a/src/tool-tiers.js
+++ b/src/tool-tiers.js
@@ -15,6 +15,7 @@
 // restarting the MCP server.
 
 import { sendCommand } from "./unity-editor-bridge.js";
+import { formatResult } from "./response-format.js";
 
 /**
  * Explicit route overrides for tools whose API endpoints
@@ -47,6 +48,41 @@ function toolNameToRoute(toolName) {
   const category = parts[0];
   const action = parts.slice(1).join("-");
   return `${category}/${action}`;
+}
+
+/**
+ * Levenshtein edit distance (small inputs: tool names).
+ */
+function levenshtein(a, b) {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr = new Array(n + 1);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+/**
+ * Return up to `limit` known tool names closest to `name` (did-you-mean),
+ * within a sane edit-distance threshold so a wild miss yields no suggestion.
+ */
+function nearestToolNames(name, knownNames, limit = 3) {
+  const threshold = Math.max(3, Math.floor(name.length / 3));
+  return knownNames
+    .map((n) => ({ n, d: levenshtein(name, n) }))
+    .filter((x) => x.d <= threshold)
+    .sort((a, b) => a.d - b.d)
+    .slice(0, limit)
+    .map((x) => x.n);
 }
 
 // ─── Core tool names (always exposed individually) ───
@@ -197,7 +233,8 @@ export function splitToolTiers(allEditorTools) {
       "Categories include: uma, animation, prefab, physics, lighting, audio, shadergraph, " +
       "amplify, terrain, particle, navmesh, ui, texture, profiler, memory, settings, " +
       "input, asmdef, scriptableobject, constraint, lod, editorprefs, playerprefs, " +
-      "vfx, graphics, sceneview, and more.",
+      "vfx, graphics, sceneview, and more. " +
+      "Pass a `category` to get each tool's full inputSchema (required params + allowed values), not just its name.",
     inputSchema: {
       type: "object",
       properties: {
@@ -252,17 +289,30 @@ export function splitToolTiers(allEditorTools) {
         // Also include dynamic-only tools for this category
         const dynamicTools = (mergedCategories[cat] || [])
           .filter((name) => !advancedMap.has(name))
-          .map((name) => ({ name, description: `(lazy-loaded from Unity plugin)` }));
+          .map((name) => ({
+            name,
+            description: `(lazy-loaded from Unity plugin)`,
+            inputSchema: null,
+          }));
 
+        // Echo each cached tool's inputSchema (WIN F) so the agent sees required
+        // params + enums BEFORE the dispatch round-trip. Lazy-only tools resolve
+        // to inputSchema:null until the C# plugin emits per-route schemas via
+        // _meta/routes. Confined to the category branch so the (potentially huge)
+        // full catalog stays terse and never re-trips the client tool-size limit.
         const all = [
-          ...matching.map((t) => ({ name: t.name, description: t.description })),
+          ...matching.map((t) => ({
+            name: t.name,
+            description: t.description,
+            inputSchema: t.inputSchema,
+          })),
           ...dynamicTools,
         ];
 
         if (all.length === 0) {
           return `No advanced tools found for category "${category}". Available categories: ${Object.keys(mergedCategories).join(", ")}`;
         }
-        return JSON.stringify(all, null, 2);
+        return formatResult(all);
       }
 
       // Full catalog grouped by category
@@ -270,25 +320,21 @@ export function splitToolTiers(allEditorTools) {
       for (const [cat, names] of Object.entries(mergedCategories)) {
         result[cat] = names;
       }
-      return JSON.stringify(
-        {
-          totalAdvancedTools: advanced.length + dynamicCount,
-          dynamicTools: dynamicCount,
-          categories: result,
-        },
-        null,
-        2
-      );
+      return formatResult({
+        totalAdvancedTools: advanced.length + dynamicCount,
+        dynamicTools: dynamicCount,
+        categories: result,
+      });
     },
   };
 
   const advancedTool = {
     name: "unity_advanced_tool",
     description:
-      "Execute an advanced/specialized Unity tool by name. Use unity_list_advanced_tools " +
-      "to discover available tools and their parameters. This provides access to 200+ " +
-      "specialized tools for animation, prefabs, physics, shaders, terrain, particles, " +
-      "UI, profiling, and more.",
+      "Execute an advanced/specialized Unity tool by name. Call unity_list_advanced_tools " +
+      "with a `category` to discover tools AND their full inputSchema (required params + " +
+      "allowed values) before calling. Provides access to 200+ specialized tools for " +
+      "animation, prefabs, physics, shaders, terrain, particles, UI, profiling, and more.",
     inputSchema: {
       type: "object",
       properties: {
@@ -300,7 +346,7 @@ export function splitToolTiers(allEditorTools) {
         params: {
           type: "object",
           description:
-            "Parameters to pass to the tool. Use unity_list_advanced_tools to see required parameters.",
+            "Parameters to pass to the tool. Call unity_list_advanced_tools with the tool's category to see its inputSchema (required params + allowed values).",
           additionalProperties: true,
         },
       },
@@ -316,6 +362,14 @@ export function splitToolTiers(allEditorTools) {
         return await targetTool.handler(params || {});
       }
 
+      // Did-you-mean over known cached tool names (WIN F): a typo'd tool name
+      // otherwise falls through to a derived lazy route and fails with an opaque
+      // bridge 404. Suggesting near names lets the agent self-correct in one hop.
+      const knownNames = [...advancedMap.keys(), ...CORE_TOOLS];
+      const didYouMean = nearestToolNames(tool, knownNames);
+      const suggestion =
+        didYouMean.length > 0 ? ` Did you mean: ${didYouMean.join(", ")}?` : "";
+
       // ─── Lazy loading fallback ───
       // Tool not in cached map — derive the route from the name and call Unity directly.
       // This allows new tools added to the C# plugin to work without restarting the MCP server.
@@ -325,13 +379,21 @@ export function splitToolTiers(allEditorTools) {
           // Log to stderr, not stdout — stdout carries the MCP JSON-RPC transport.
           console.error(`[MCP] Lazy-loading tool "${tool}" via route "${route}"`);
           const result = await sendCommand(route, params || {});
-          return JSON.stringify(result, null, 2);
+          // The bridge returns HTTP 200 even for an unknown endpoint (a structured
+          // {error:"Unknown API endpoint: ..."}), so a typo'd route does NOT throw.
+          // Detect that case so the did-you-mean still fires instead of leaking an
+          // opaque "successful" error back to the agent.
+          const errText = result?.error || result?.data?.error;
+          if (typeof errText === "string" && /unknown api endpoint/i.test(errText)) {
+            return `Error: Unknown tool "${tool}" (no route "${route}").${suggestion} Use unity_list_advanced_tools to see available tools.`;
+          }
+          return formatResult(result);
         } catch (err) {
-          return `Error executing "${tool}" (lazy route: ${route}): ${err.message}`;
+          return `Error executing "${tool}" (lazy route: ${route}): ${err.message}.${suggestion}`;
         }
       }
 
-      return `Error: Unknown tool "${tool}". Use unity_list_advanced_tools to see available tools.`;
+      return `Error: Unknown tool "${tool}".${suggestion} Use unity_list_advanced_tools to see available tools.`;
     },
   };
 

--- a/src/tools/context-tools.js
+++ b/src/tools/context-tools.js
@@ -4,6 +4,8 @@
 
 import * as bridge from "../unity-editor-bridge.js";
 
+import { formatResult } from "../response-format.js";
+
 export const contextTools = [
   {
     name: "unity_get_project_context",
@@ -27,7 +29,7 @@ export const contextTools = [
     },
     handler: async ({ category } = {}) => {
       const data = await bridge.getProjectContext(category || null);
-      return JSON.stringify(data, null, 2);
+      return formatResult(data);
     },
   },
 ];

--- a/src/tools/editor-tools.js
+++ b/src/tools/editor-tools.js
@@ -1,19 +1,21 @@
 ﻿// AnkleBreaker Unity MCP â€” Tool definitions for Unity Editor operations (via HTTP bridge)
 import * as bridge from "../unity-editor-bridge.js";
 
+import { formatResult } from "../response-format.js";
+
 export const editorTools = [
   // â”€â”€â”€ Connection â”€â”€â”€
   {
     name: "unity_editor_ping",
     description: "Check if the Unity Editor bridge is running and responsive. Returns editor version, project name, and connection status.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.ping(), null, 2),
+    handler: async () => formatResult(await bridge.ping()),
   },
   {
     name: "unity_editor_state",
     description: "Get the current Unity Editor state: play mode, compilation status, active scene, project path.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.getEditorState(), null, 2),
+    handler: async () => formatResult(await bridge.getEditorState()),
   },
 
   // â”€â”€â”€ Scene Management â”€â”€â”€
@@ -21,7 +23,7 @@ export const editorTools = [
     name: "unity_scene_info",
     description: "Get information about the currently open scene(s), including name, path, dirty state, and root game objects.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.getSceneInfo(), null, 2),
+    handler: async () => formatResult(await bridge.getSceneInfo()),
   },
   {
     name: "unity_scene_open",
@@ -33,19 +35,19 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async ({ path }) => JSON.stringify(await bridge.openScene(path), null, 2),
+    handler: async ({ path }) => formatResult(await bridge.openScene(path)),
   },
   {
     name: "unity_scene_save",
     description: "Save the current scene.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.saveScene(), null, 2),
+    handler: async () => formatResult(await bridge.saveScene()),
   },
   {
     name: "unity_scene_new",
     description: "Create a new empty scene.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.newScene(), null, 2),
+    handler: async () => formatResult(await bridge.newScene()),
   },
   {
     name: "unity_scene_hierarchy",
@@ -58,7 +60,7 @@ export const editorTools = [
         parentPath: { type: "string", description: "Only return hierarchy under this GameObject path (e.g. 'Canvas/Panel'). Useful for exploring specific subtrees in large scenes." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getHierarchy(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getHierarchy(params)),
   },
 
   // â”€â”€â”€ GameObject Operations â”€â”€â”€
@@ -90,7 +92,7 @@ export const editorTools = [
       },
       required: ["name"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createGameObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createGameObject(params)),
   },
   {
     name: "unity_gameobject_delete",
@@ -102,7 +104,7 @@ export const editorTools = [
         instanceId: { type: "number", description: "Instance ID (alternative to path)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.deleteGameObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.deleteGameObject(params)),
   },
   {
     name: "unity_gameobject_info",
@@ -114,7 +116,7 @@ export const editorTools = [
         instanceId: { type: "number", description: "Instance ID (alternative to path)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getGameObjectInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getGameObjectInfo(params)),
   },
   {
     name: "unity_gameobject_set_transform",
@@ -130,7 +132,7 @@ export const editorTools = [
         local: { type: "boolean", description: "If true, set local transform instead of world (default: false)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setTransform(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTransform(params)),
   },
 
   // â”€â”€â”€ Component Operations â”€â”€â”€
@@ -145,7 +147,7 @@ export const editorTools = [
       },
       required: ["gameObjectPath", "componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addComponent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addComponent(params)),
   },
   {
     name: "unity_component_remove",
@@ -159,7 +161,7 @@ export const editorTools = [
       },
       required: ["gameObjectPath", "componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeComponent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeComponent(params)),
   },
   {
     name: "unity_component_get_properties",
@@ -172,7 +174,7 @@ export const editorTools = [
       },
       required: ["gameObjectPath", "componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getComponentProperties(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getComponentProperties(params)),
   },
   {
     name: "unity_component_set_property",
@@ -204,7 +206,7 @@ export const editorTools = [
           params.value = false;
         }
       }
-      return JSON.stringify(await bridge.setComponentProperty(params), null, 2);
+      return formatResult(await bridge.setComponentProperty(params));
     },
   },
   {
@@ -225,7 +227,7 @@ export const editorTools = [
       },
       required: ["propertyName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setComponentReference(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setComponentReference(params)),
   },
   {
     name: "unity_component_batch_wire",
@@ -255,7 +257,7 @@ export const editorTools = [
       },
       required: ["references"],
     },
-    handler: async (params) => JSON.stringify(await bridge.batchWireReferences(params), null, 2),
+    handler: async (params) => formatResult(await bridge.batchWireReferences(params)),
   },
   {
     name: "unity_component_get_referenceable",
@@ -271,7 +273,7 @@ export const editorTools = [
       },
       required: ["propertyName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getReferenceableObjects(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getReferenceableObjects(params)),
   },
 
   // â”€â”€â”€ Asset Management â”€â”€â”€
@@ -288,7 +290,7 @@ export const editorTools = [
         maxResults: { type: "number", description: "Maximum assets to return (default: 500). Use lower values for large projects." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getAssetList(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAssetList(params)),
   },
   {
     name: "unity_asset_import",
@@ -301,7 +303,7 @@ export const editorTools = [
       },
       required: ["sourcePath", "destinationPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.importAsset(params), null, 2),
+    handler: async (params) => formatResult(await bridge.importAsset(params)),
   },
   {
     name: "unity_asset_delete",
@@ -313,7 +315,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.deleteAsset(params), null, 2),
+    handler: async (params) => formatResult(await bridge.deleteAsset(params)),
   },
   {
     name: "unity_asset_create_prefab",
@@ -326,7 +328,7 @@ export const editorTools = [
       },
       required: ["gameObjectPath", "savePath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createPrefab(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createPrefab(params)),
   },
   {
     name: "unity_asset_instantiate_prefab",
@@ -342,7 +344,7 @@ export const editorTools = [
       },
       required: ["prefabPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.instantiatePrefab(params), null, 2),
+    handler: async (params) => formatResult(await bridge.instantiatePrefab(params)),
   },
 
   // â”€â”€â”€ Script / Code Operations â”€â”€â”€
@@ -358,7 +360,7 @@ export const editorTools = [
       },
       required: ["path", "content"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createScript(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createScript(params)),
   },
   {
     name: "unity_script_read",
@@ -370,7 +372,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.readScript(params), null, 2),
+    handler: async (params) => formatResult(await bridge.readScript(params)),
   },
   {
     name: "unity_script_update",
@@ -383,7 +385,7 @@ export const editorTools = [
       },
       required: ["path", "content"],
     },
-    handler: async (params) => JSON.stringify(await bridge.updateScript(params), null, 2),
+    handler: async (params) => formatResult(await bridge.updateScript(params)),
   },
   {
     name: "unity_execute_code",
@@ -395,7 +397,7 @@ export const editorTools = [
       },
       required: ["code"],
     },
-    handler: async ({ code }) => JSON.stringify(await bridge.executeCode(code), null, 2),
+    handler: async ({ code }) => formatResult(await bridge.executeCode(code)),
   },
 
   // â”€â”€â”€ Material / Rendering â”€â”€â”€
@@ -412,7 +414,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createMaterial(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createMaterial(params)),
   },
   {
     name: "unity_renderer_set_material",
@@ -426,7 +428,7 @@ export const editorTools = [
       },
       required: ["gameObjectPath", "materialPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setMaterial(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setMaterial(params)),
   },
 
   // â”€â”€â”€ Build â”€â”€â”€
@@ -451,7 +453,7 @@ export const editorTools = [
       },
       required: ["target", "outputPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.buildProject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.buildProject(params)),
   },
 
   // â”€â”€â”€ Console / Logging â”€â”€â”€
@@ -465,13 +467,13 @@ export const editorTools = [
         type: { type: "string", description: "Filter: 'error', 'warning', 'info', or 'all' (default: 'all')" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getConsoleLog(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getConsoleLog(params)),
   },
   {
     name: "unity_console_clear",
     description: "Clear the Unity console log.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.clearConsoleLog(), null, 2),
+    handler: async () => formatResult(await bridge.clearConsoleLog()),
   },
 
   // â”€â”€â”€ Play Mode â”€â”€â”€
@@ -491,7 +493,7 @@ export const editorTools = [
         severity: { type: "string", description: "Filter: 'error', 'warning', or 'all' (default: 'all')" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getCompilationErrors(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getCompilationErrors(params)),
   },
 
   // ─── Play Mode ───
@@ -505,7 +507,7 @@ export const editorTools = [
       },
       required: ["action"],
     },
-    handler: async ({ action }) => JSON.stringify(await bridge.playMode(action), null, 2),
+    handler: async ({ action }) => formatResult(await bridge.playMode(action)),
   },
 
   // â”€â”€â”€ Editor Menu â”€â”€â”€
@@ -519,7 +521,7 @@ export const editorTools = [
       },
       required: ["menuPath"],
     },
-    handler: async ({ menuPath }) => JSON.stringify(await bridge.executeMenuItem(menuPath), null, 2),
+    handler: async ({ menuPath }) => formatResult(await bridge.executeMenuItem(menuPath)),
   },
 
   // â”€â”€â”€ Project Info â”€â”€â”€
@@ -527,7 +529,7 @@ export const editorTools = [
     name: "unity_project_info",
     description: "Get project information: name, path, Unity version, render pipeline, packages, build settings.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.getProjectInfo(), null, 2),
+    handler: async () => formatResult(await bridge.getProjectInfo()),
   },
 
   // â”€â”€â”€ Animation â”€â”€â”€
@@ -541,7 +543,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createAnimatorController(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAnimatorController(params)),
   },
   {
     name: "unity_animation_controller_info",
@@ -553,7 +555,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getAnimatorControllerInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAnimatorControllerInfo(params)),
   },
   {
     name: "unity_animation_add_parameter",
@@ -568,7 +570,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "parameterName", "parameterType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAnimationParameter(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAnimationParameter(params)),
   },
   {
     name: "unity_animation_remove_parameter",
@@ -581,7 +583,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "parameterName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAnimationParameter(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAnimationParameter(params)),
   },
   {
     name: "unity_animation_add_state",
@@ -598,7 +600,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "stateName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAnimationState(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAnimationState(params)),
   },
   {
     name: "unity_animation_remove_state",
@@ -612,7 +614,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "stateName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAnimationState(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAnimationState(params)),
   },
   {
     name: "unity_animation_add_transition",
@@ -645,7 +647,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "destinationState"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAnimationTransition(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAnimationTransition(params)),
   },
   {
     name: "unity_animation_create_clip",
@@ -659,7 +661,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createAnimationClip(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAnimationClip(params)),
   },
   {
     name: "unity_animation_clip_info",
@@ -671,7 +673,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getAnimationClipInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAnimationClipInfo(params)),
   },
   {
     name: "unity_animation_set_clip_curve",
@@ -697,7 +699,7 @@ export const editorTools = [
       },
       required: ["clipPath", "propertyName", "keyframes"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setAnimationClipCurve(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setAnimationClipCurve(params)),
   },
   {
     name: "unity_animation_add_layer",
@@ -711,7 +713,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "layerName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAnimationLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAnimationLayer(params)),
   },
   {
     name: "unity_animation_assign_controller",
@@ -725,7 +727,7 @@ export const editorTools = [
       },
       required: ["controllerPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.assignAnimatorController(params), null, 2),
+    handler: async (params) => formatResult(await bridge.assignAnimatorController(params)),
   },
   {
     name: "unity_animation_get_curve_keyframes",
@@ -740,7 +742,7 @@ export const editorTools = [
       },
       required: ["clipPath", "propertyName", "typeName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getCurveKeyframes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getCurveKeyframes(params)),
   },
   {
     name: "unity_animation_remove_curve",
@@ -755,7 +757,7 @@ export const editorTools = [
       },
       required: ["clipPath", "propertyName", "typeName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeCurve(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeCurve(params)),
   },
   {
     name: "unity_animation_add_keyframe",
@@ -777,7 +779,7 @@ export const editorTools = [
       },
       required: ["clipPath", "propertyName", "typeName", "time", "value"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addKeyframe(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addKeyframe(params)),
   },
   {
     name: "unity_animation_remove_keyframe",
@@ -793,7 +795,7 @@ export const editorTools = [
       },
       required: ["clipPath", "propertyName", "typeName", "keyframeIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeKeyframe(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeKeyframe(params)),
   },
   {
     name: "unity_animation_add_event",
@@ -810,7 +812,7 @@ export const editorTools = [
       },
       required: ["clipPath", "functionName", "time"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAnimationEvent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAnimationEvent(params)),
   },
   {
     name: "unity_animation_remove_event",
@@ -823,7 +825,7 @@ export const editorTools = [
       },
       required: ["clipPath", "eventIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAnimationEvent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAnimationEvent(params)),
   },
   {
     name: "unity_animation_get_events",
@@ -835,7 +837,7 @@ export const editorTools = [
       },
       required: ["clipPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getAnimationEvents(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAnimationEvents(params)),
   },
   {
     name: "unity_animation_set_clip_settings",
@@ -858,7 +860,7 @@ export const editorTools = [
       },
       required: ["clipPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setClipSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setClipSettings(params)),
   },
   {
     name: "unity_animation_remove_transition",
@@ -874,7 +876,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "sourceState"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAnimationTransition(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAnimationTransition(params)),
   },
   {
     name: "unity_animation_remove_layer",
@@ -887,7 +889,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "layerIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAnimationLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAnimationLayer(params)),
   },
   {
     name: "unity_animation_create_blend_tree",
@@ -917,7 +919,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "blendTreeName", "blendParameter"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createBlendTree(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createBlendTree(params)),
   },
   {
     name: "unity_animation_get_blend_tree",
@@ -931,7 +933,7 @@ export const editorTools = [
       },
       required: ["controllerPath", "stateName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getBlendTreeInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getBlendTreeInfo(params)),
   },
 
   // â”€â”€â”€ Prefab (Advanced) â”€â”€â”€
@@ -946,7 +948,7 @@ export const editorTools = [
         instanceId: { type: "number", description: "Instance ID of a prefab instance" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getPrefabInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPrefabInfo(params)),
   },
   {
     name: "unity_prefab_create_variant",
@@ -959,7 +961,7 @@ export const editorTools = [
       },
       required: ["basePrefabPath", "variantPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createPrefabVariant(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createPrefabVariant(params)),
   },
   {
     name: "unity_prefab_apply_overrides",
@@ -971,7 +973,7 @@ export const editorTools = [
         instanceId: { type: "number", description: "Instance ID (alternative to path)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.applyPrefabOverrides(params), null, 2),
+    handler: async (params) => formatResult(await bridge.applyPrefabOverrides(params)),
   },
   {
     name: "unity_prefab_revert_overrides",
@@ -983,7 +985,7 @@ export const editorTools = [
         instanceId: { type: "number", description: "Instance ID (alternative to path)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.revertPrefabOverrides(params), null, 2),
+    handler: async (params) => formatResult(await bridge.revertPrefabOverrides(params)),
   },
   {
     name: "unity_prefab_unpack",
@@ -996,7 +998,7 @@ export const editorTools = [
         completely: { type: "boolean", description: "If true, unpack completely including nested prefabs (default: false)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.unpackPrefab(params), null, 2),
+    handler: async (params) => formatResult(await bridge.unpackPrefab(params)),
   },
   {
     name: "unity_set_object_reference",
@@ -1013,7 +1015,7 @@ export const editorTools = [
       },
       required: ["propertyName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setObjectReference(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setObjectReference(params)),
   },
   {
     name: "unity_gameobject_duplicate",
@@ -1026,7 +1028,7 @@ export const editorTools = [
         newName: { type: "string", description: "Name for the duplicate (default: original name + ' (Copy)')" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.duplicateGameObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.duplicateGameObject(params)),
   },
   {
     name: "unity_gameobject_set_active",
@@ -1040,7 +1042,7 @@ export const editorTools = [
       },
       required: ["active"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setGameObjectActive(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setGameObjectActive(params)),
   },
   {
     name: "unity_gameobject_reparent",
@@ -1054,7 +1056,7 @@ export const editorTools = [
         worldPositionStays: { type: "boolean", description: "Maintain world position after reparenting (default: true)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.reparentGameObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.reparentGameObject(params)),
   },
 
   // â”€â”€â”€ Prefab Asset (Direct Editing) â”€â”€â”€
@@ -1069,7 +1071,7 @@ export const editorTools = [
       },
       required: ["assetPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getPrefabAssetHierarchy(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPrefabAssetHierarchy(params)),
   },
   {
     name: "unity_prefab_get_properties",
@@ -1083,7 +1085,7 @@ export const editorTools = [
       },
       required: ["assetPath", "componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getPrefabAssetProperties(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPrefabAssetProperties(params)),
   },
   {
     name: "unity_prefab_set_property",
@@ -1099,7 +1101,7 @@ export const editorTools = [
       },
       required: ["assetPath", "componentType", "propertyName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setPrefabAssetProperty(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setPrefabAssetProperty(params)),
   },
   {
     name: "unity_prefab_add_component",
@@ -1113,7 +1115,7 @@ export const editorTools = [
       },
       required: ["assetPath", "componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addPrefabAssetComponent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addPrefabAssetComponent(params)),
   },
   {
     name: "unity_prefab_remove_component",
@@ -1128,7 +1130,7 @@ export const editorTools = [
       },
       required: ["assetPath", "componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removePrefabAssetComponent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removePrefabAssetComponent(params)),
   },
   {
     name: "unity_prefab_set_reference",
@@ -1147,7 +1149,7 @@ export const editorTools = [
       },
       required: ["assetPath", "propertyName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setPrefabAssetReference(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setPrefabAssetReference(params)),
   },
   {
     name: "unity_prefab_add_gameobject",
@@ -1165,7 +1167,7 @@ export const editorTools = [
       },
       required: ["assetPath", "name"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addPrefabAssetGameObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addPrefabAssetGameObject(params)),
   },
   {
     name: "unity_prefab_remove_gameobject",
@@ -1178,7 +1180,7 @@ export const editorTools = [
       },
       required: ["assetPath", "prefabPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removePrefabAssetGameObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removePrefabAssetGameObject(params)),
   },
 
   // â”€â”€â”€ Prefab Variant Management â”€â”€â”€
@@ -1192,7 +1194,7 @@ export const editorTools = [
       },
       required: ["assetPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getPrefabVariantInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPrefabVariantInfo(params)),
   },
   {
     name: "unity_prefab_compare_variant",
@@ -1204,7 +1206,7 @@ export const editorTools = [
       },
       required: ["assetPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.comparePrefabVariantToBase(params), null, 2),
+    handler: async (params) => formatResult(await bridge.comparePrefabVariantToBase(params)),
   },
   {
     name: "unity_prefab_apply_variant_override",
@@ -1219,7 +1221,7 @@ export const editorTools = [
       },
       required: ["assetPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.applyPrefabVariantOverride(params), null, 2),
+    handler: async (params) => formatResult(await bridge.applyPrefabVariantOverride(params)),
   },
   {
     name: "unity_prefab_revert_variant_override",
@@ -1234,7 +1236,7 @@ export const editorTools = [
       },
       required: ["assetPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.revertPrefabVariantOverride(params), null, 2),
+    handler: async (params) => formatResult(await bridge.revertPrefabVariantOverride(params)),
   },
   {
     name: "unity_prefab_transfer_variant_overrides",
@@ -1247,7 +1249,7 @@ export const editorTools = [
       },
       required: ["sourceAssetPath", "targetAssetPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.transferPrefabVariantOverrides(params), null, 2),
+    handler: async (params) => formatResult(await bridge.transferPrefabVariantOverrides(params)),
   },
 
   // â”€â”€â”€ Physics â”€â”€â”€
@@ -1265,7 +1267,7 @@ export const editorTools = [
       },
       required: ["origin", "direction"],
     },
-    handler: async (params) => JSON.stringify(await bridge.physicsRaycast(params), null, 2),
+    handler: async (params) => formatResult(await bridge.physicsRaycast(params)),
   },
   {
     name: "unity_physics_overlap_sphere",
@@ -1279,7 +1281,7 @@ export const editorTools = [
       },
       required: ["center", "radius"],
     },
-    handler: async (params) => JSON.stringify(await bridge.physicsOverlapSphere(params), null, 2),
+    handler: async (params) => formatResult(await bridge.physicsOverlapSphere(params)),
   },
   {
     name: "unity_physics_overlap_box",
@@ -1293,13 +1295,13 @@ export const editorTools = [
       },
       required: ["center", "halfExtents"],
     },
-    handler: async (params) => JSON.stringify(await bridge.physicsOverlapBox(params), null, 2),
+    handler: async (params) => formatResult(await bridge.physicsOverlapBox(params)),
   },
   {
     name: "unity_physics_collision_matrix",
     description: "Get the physics collision matrix showing which layers collide with each other.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getCollisionMatrix(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getCollisionMatrix(params)),
   },
   {
     name: "unity_physics_set_collision_layer",
@@ -1314,7 +1316,7 @@ export const editorTools = [
         ignore: { type: "boolean", description: "If true, layers will ignore each other (default: true)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setCollisionLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setCollisionLayer(params)),
   },
   {
     name: "unity_physics_set_gravity",
@@ -1325,7 +1327,7 @@ export const editorTools = [
         gravity: { type: "object", properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } }, description: "New gravity vector (omit to just read current)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setGravity(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setGravity(params)),
   },
 
   // â”€â”€â”€ Lighting â”€â”€â”€
@@ -1333,7 +1335,7 @@ export const editorTools = [
     name: "unity_lighting_info",
     description: "Get info about all lights in the scene plus environment/fog settings.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getLightingInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getLightingInfo(params)),
   },
   {
     name: "unity_lighting_create",
@@ -1352,7 +1354,7 @@ export const editorTools = [
         rotation: { type: "object", properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } } },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createLight(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createLight(params)),
   },
   {
     name: "unity_lighting_set_environment",
@@ -1370,7 +1372,7 @@ export const editorTools = [
         skyboxMaterialPath: { type: "string", description: "Asset path to skybox material" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setEnvironment(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setEnvironment(params)),
   },
   {
     name: "unity_lighting_create_reflection_probe",
@@ -1385,7 +1387,7 @@ export const editorTools = [
         mode: { type: "string", enum: ["Baked", "Realtime", "Custom"], description: "Probe mode" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createReflectionProbe(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createReflectionProbe(params)),
   },
   {
     name: "unity_lighting_create_light_probe_group",
@@ -1397,7 +1399,7 @@ export const editorTools = [
         position: { type: "object", properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } } },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createLightProbeGroup(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createLightProbeGroup(params)),
   },
 
   // â”€â”€â”€ Audio â”€â”€â”€
@@ -1405,7 +1407,7 @@ export const editorTools = [
     name: "unity_audio_info",
     description: "Get info about all AudioSources and AudioListeners in the scene.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getAudioInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAudioInfo(params)),
   },
   {
     name: "unity_audio_create_source",
@@ -1427,7 +1429,7 @@ export const editorTools = [
         position: { type: "object", properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } } },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createAudioSource(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAudioSource(params)),
   },
   {
     name: "unity_audio_set_global",
@@ -1439,7 +1441,7 @@ export const editorTools = [
         pause: { type: "boolean", description: "Pause/unpause all audio" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setGlobalAudio(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setGlobalAudio(params)),
   },
 
   // â”€â”€â”€ Tags & Layers â”€â”€â”€
@@ -1447,7 +1449,7 @@ export const editorTools = [
     name: "unity_taglayer_info",
     description: "Get all tags, layers, and sorting layers in the project.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getTagsAndLayers(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTagsAndLayers(params)),
   },
   {
     name: "unity_taglayer_add_tag",
@@ -1459,7 +1461,7 @@ export const editorTools = [
       },
       required: ["tag"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addTag(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addTag(params)),
   },
   {
     name: "unity_taglayer_set_tag",
@@ -1473,7 +1475,7 @@ export const editorTools = [
       },
       required: ["tag"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTag(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTag(params)),
   },
   {
     name: "unity_taglayer_set_layer",
@@ -1488,7 +1490,7 @@ export const editorTools = [
         includeChildren: { type: "boolean", description: "Apply to all children recursively" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setLayer(params)),
   },
   {
     name: "unity_taglayer_set_static",
@@ -1502,7 +1504,7 @@ export const editorTools = [
         includeChildren: { type: "boolean", description: "Apply to all children recursively" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setStatic(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setStatic(params)),
   },
 
   // â”€â”€â”€ Selection & Scene View â”€â”€â”€
@@ -1510,7 +1512,7 @@ export const editorTools = [
     name: "unity_selection_get",
     description: "Get the currently selected GameObjects in the Unity Editor.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getSelection(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getSelection(params)),
   },
   {
     name: "unity_selection_set",
@@ -1523,7 +1525,7 @@ export const editorTools = [
         instanceId: { type: "integer", description: "Instance ID of GameObject to select" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setSelection(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setSelection(params)),
   },
   {
     name: "unity_selection_focus_scene_view",
@@ -1539,7 +1541,7 @@ export const editorTools = [
         orthographic: { type: "boolean", description: "Toggle orthographic/perspective" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.focusSceneView(params), null, 2),
+    handler: async (params) => formatResult(await bridge.focusSceneView(params)),
   },
   {
     name: "unity_selection_find_by_type",
@@ -1551,7 +1553,7 @@ export const editorTools = [
       },
       required: ["typeName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.findObjectsByType(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findObjectsByType(params)),
   },
 
   // â”€â”€â”€ Agent Management â”€â”€â”€
@@ -1577,7 +1579,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createInputActions(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createInputActions(params)),
   },
   {
     name: "unity_input_info",
@@ -1589,7 +1591,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getInputActionsInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getInputActionsInfo(params)),
   },
   {
     name: "unity_input_add_map",
@@ -1602,7 +1604,7 @@ export const editorTools = [
       },
       required: ["path", "mapName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addInputActionMap(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addInputActionMap(params)),
   },
   {
     name: "unity_input_remove_map",
@@ -1615,7 +1617,7 @@ export const editorTools = [
       },
       required: ["path", "mapName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeInputActionMap(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeInputActionMap(params)),
   },
   {
     name: "unity_input_add_action",
@@ -1631,7 +1633,7 @@ export const editorTools = [
       },
       required: ["path", "mapName", "actionName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addInputAction(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addInputAction(params)),
   },
   {
     name: "unity_input_remove_action",
@@ -1645,7 +1647,7 @@ export const editorTools = [
       },
       required: ["path", "mapName", "actionName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeInputAction(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeInputAction(params)),
   },
   {
     name: "unity_input_add_binding",
@@ -1660,7 +1662,7 @@ export const editorTools = [
       },
       required: ["path", "mapName", "actionName", "bindingPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addInputBinding(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addInputBinding(params)),
   },
   {
     name: "unity_input_add_composite_binding",
@@ -1688,7 +1690,7 @@ export const editorTools = [
       },
       required: ["path", "mapName", "actionName", "compositeName", "parts"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addInputCompositeBinding(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addInputCompositeBinding(params)),
   },
 
   // â”€â”€â”€ Assembly Definitions â”€â”€â”€
@@ -1733,7 +1735,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createAssemblyDef(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAssemblyDef(params)),
   },
   {
     name: "unity_asmdef_info",
@@ -1745,7 +1747,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getAssemblyDefInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAssemblyDefInfo(params)),
   },
   {
     name: "unity_asmdef_list",
@@ -1757,7 +1759,7 @@ export const editorTools = [
         includePackages: { type: "boolean", description: "Also list assembly definitions from Packages/ (default: false)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listAssemblyDefs(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listAssemblyDefs(params)),
   },
   {
     name: "unity_asmdef_add_references",
@@ -1774,7 +1776,7 @@ export const editorTools = [
       },
       required: ["path", "references"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAssemblyDefReferences(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAssemblyDefReferences(params)),
   },
   {
     name: "unity_asmdef_remove_references",
@@ -1791,7 +1793,7 @@ export const editorTools = [
       },
       required: ["path", "references"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAssemblyDefReferences(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAssemblyDefReferences(params)),
   },
   {
     name: "unity_asmdef_set_platforms",
@@ -1813,7 +1815,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setAssemblyDefPlatforms(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setAssemblyDefPlatforms(params)),
   },
   {
     name: "unity_asmdef_update_settings",
@@ -1841,7 +1843,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.updateAssemblyDefSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.updateAssemblyDefSettings(params)),
   },
   {
     name: "unity_asmdef_create_ref",
@@ -1854,7 +1856,7 @@ export const editorTools = [
       },
       required: ["path", "reference"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createAssemblyRef(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAssemblyRef(params)),
   },
 
   // â”€â”€â”€ Profiler â”€â”€â”€
@@ -1869,19 +1871,19 @@ export const editorTools = [
       },
       required: ["enabled"],
     },
-    handler: async (params) => JSON.stringify(await bridge.enableProfiler(params), null, 2),
+    handler: async (params) => formatResult(await bridge.enableProfiler(params)),
   },
   {
     name: "unity_profiler_stats",
     description: "Get current rendering statistics: draw calls, batches, triangles, vertices, set-pass calls, frame time, render time, shadow casters, and more. The profiler does NOT need to be enabled for this â€” stats come from UnityStats which is always available.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getRenderingStats(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getRenderingStats(params)),
   },
   {
     name: "unity_profiler_memory",
     description: "Get detailed memory usage breakdown: total allocated, reserved, Mono heap used/size, graphics driver memory, temp allocator size, and GC info. Values are returned in both bytes and human-readable MB.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getMemoryInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getMemoryInfo(params)),
   },
   {
     name: "unity_profiler_frame_data",
@@ -1895,13 +1897,13 @@ export const editorTools = [
         minTimeMs: { type: "number", description: "Minimum total time in ms to include an item (default: 0.1)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getProfilerFrameData(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getProfilerFrameData(params)),
   },
   {
     name: "unity_profiler_analyze",
     description: "Run a comprehensive performance analysis combining memory, rendering stats, profiler frame data, and scene complexity. Returns optimization suggestions based on configurable thresholds (e.g. too many batches, high triangle count, excessive set-pass calls, GPU memory usage, shadow casters).",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.analyzePerformance(params), null, 2),
+    handler: async (params) => formatResult(await bridge.analyzePerformance(params)),
   },
 
   // â”€â”€â”€ Frame Debugger â”€â”€â”€
@@ -1915,13 +1917,13 @@ export const editorTools = [
       },
       required: ["enabled"],
     },
-    handler: async (params) => JSON.stringify(await bridge.enableFrameDebugger(params), null, 2),
+    handler: async (params) => formatResult(await bridge.enableFrameDebugger(params)),
   },
   {
     name: "unity_debugger_events",
     description: "List all rendering events (draw calls) captured by the Frame Debugger. The Frame Debugger must be enabled first. Returns event index, type, and name for each draw call.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getFrameDebuggerEvents(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getFrameDebuggerEvents(params)),
   },
   {
     name: "unity_debugger_event_details",
@@ -1933,7 +1935,7 @@ export const editorTools = [
       },
       required: ["eventIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getFrameDebuggerEventDetails(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getFrameDebuggerEventDetails(params)),
   },
 
   // â”€â”€â”€ Memory Profiler â”€â”€â”€
@@ -1941,7 +1943,7 @@ export const editorTools = [
     name: "unity_memory_status",
     description: "Check Memory Profiler status: whether the com.unity.memoryprofiler package is installed, available commands, and a quick memory summary. Always call this first before other memory profiler commands.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getMemoryStatus(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getMemoryStatus(params)),
   },
   {
     name: "unity_memory_breakdown",
@@ -1953,7 +1955,7 @@ export const editorTools = [
         maxPerCategory: { type: "number", description: "Max assets to list per category when includeDetails=true (default: 5)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getMemoryBreakdown(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getMemoryBreakdown(params)),
   },
   {
     name: "unity_memory_top_assets",
@@ -1965,7 +1967,7 @@ export const editorTools = [
         type: { type: "string", description: "Filter by asset type: texture, rendertexture, mesh, audio, material, shader, animation, font (default: all)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getTopMemoryConsumers(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTopMemoryConsumers(params)),
   },
   {
     name: "unity_memory_snapshot",
@@ -1976,7 +1978,7 @@ export const editorTools = [
         path: { type: "string", description: "Directory to save snapshot in (default: temp cache)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.takeMemorySnapshot(params), null, 2),
+    handler: async (params) => formatResult(await bridge.takeMemorySnapshot(params)),
   },
 
   // â”€â”€â”€ Shader Graph â”€â”€â”€
@@ -1984,7 +1986,7 @@ export const editorTools = [
     name: "unity_shadergraph_status",
     description: "Check which graph packages are installed: Shader Graph (com.unity.shadergraph) and Visual Effect Graph (com.unity.visualeffectgraph). Returns available commands based on installed packages.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getShaderGraphStatus(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getShaderGraphStatus(params)),
   },
   {
     name: "unity_shader_list",
@@ -1997,7 +1999,7 @@ export const editorTools = [
         maxResults: { type: "number", description: "Maximum results to return (default: 100)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listShaders(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listShaders(params)),
   },
   {
     name: "unity_shadergraph_list",
@@ -2009,7 +2011,7 @@ export const editorTools = [
         maxResults: { type: "number", description: "Maximum results (default: 100)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listShaderGraphs(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listShaderGraphs(params)),
   },
   {
     name: "unity_shadergraph_info",
@@ -2021,7 +2023,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getShaderGraphInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getShaderGraphInfo(params)),
   },
   {
     name: "unity_shader_get_properties",
@@ -2033,7 +2035,7 @@ export const editorTools = [
         shaderName: { type: "string", description: "Shader name (e.g. 'Universal Render Pipeline/Lit'). Alternative to path." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getShaderProperties(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getShaderProperties(params)),
   },
   {
     name: "unity_shadergraph_create",
@@ -2046,7 +2048,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createShaderGraph(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createShaderGraph(params)),
   },
   {
     name: "unity_shadergraph_open",
@@ -2058,19 +2060,19 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.openShaderGraph(params), null, 2),
+    handler: async (params) => formatResult(await bridge.openShaderGraph(params)),
   },
   {
     name: "unity_shadergraph_list_subgraphs",
     description: "List all Sub Graph (.shadersubgraph) assets in the project. Sub Graphs are reusable node groups for Shader Graphs. Requires Shader Graph package.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.listSubGraphs(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listSubGraphs(params)),
   },
   {
     name: "unity_vfx_list",
     description: "List all Visual Effect Graph assets in the project. Requires Visual Effect Graph package (com.unity.visualeffectgraph).",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.listVFXGraphs(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listVFXGraphs(params)),
   },
   {
     name: "unity_vfx_open",
@@ -2082,7 +2084,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.openVFXGraph(params), null, 2),
+    handler: async (params) => formatResult(await bridge.openVFXGraph(params)),
   },
   {
     name: "unity_shadergraph_get_nodes",
@@ -2094,7 +2096,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getShaderGraphNodes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getShaderGraphNodes(params)),
   },
   {
     name: "unity_shadergraph_get_edges",
@@ -2106,7 +2108,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getShaderGraphEdges(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getShaderGraphEdges(params)),
   },
   {
     name: "unity_shadergraph_add_node",
@@ -2121,7 +2123,7 @@ export const editorTools = [
       },
       required: ["path", "nodeType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addShaderGraphNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addShaderGraphNode(params)),
   },
   {
     name: "unity_shadergraph_remove_node",
@@ -2134,7 +2136,7 @@ export const editorTools = [
       },
       required: ["path", "nodeId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeShaderGraphNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeShaderGraphNode(params)),
   },
   {
     name: "unity_shadergraph_connect",
@@ -2150,7 +2152,7 @@ export const editorTools = [
       },
       required: ["path", "outputNodeId", "outputSlotId", "inputNodeId", "inputSlotId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.connectShaderGraphNodes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.connectShaderGraphNodes(params)),
   },
   {
     name: "unity_shadergraph_disconnect",
@@ -2166,7 +2168,7 @@ export const editorTools = [
       },
       required: ["path", "outputNodeId", "outputSlotId", "inputNodeId", "inputSlotId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.disconnectShaderGraphNodes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.disconnectShaderGraphNodes(params)),
   },
   {
     name: "unity_shadergraph_set_node_property",
@@ -2181,13 +2183,13 @@ export const editorTools = [
       },
       required: ["path", "nodeId", "propertyName", "value"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setShaderGraphNodeProperty(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setShaderGraphNodeProperty(params)),
   },
   {
     name: "unity_shadergraph_get_node_types",
     description: "List all available Shader Graph node types by reflecting over the ShaderGraph assembly. Returns type names, categories, and full class names. Useful for discovering available nodes before adding them.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getShaderGraphNodeTypes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getShaderGraphNodeTypes(params)),
   },
 
   // â”€â”€â”€ Amplify Shader Editor â”€â”€â”€
@@ -2195,7 +2197,7 @@ export const editorTools = [
     name: "unity_amplify_status",
     description: "Check if Amplify Shader Editor is installed in the project. Returns available commands, shader count, and function count. Only works when Amplify Shader Editor is imported.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyStatus(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyStatus(params)),
   },
   {
     name: "unity_amplify_list",
@@ -2207,7 +2209,7 @@ export const editorTools = [
         maxResults: { type: "number", description: "Maximum results (default: 100)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listAmplifyShaders(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listAmplifyShaders(params)),
   },
   {
     name: "unity_amplify_info",
@@ -2219,7 +2221,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyShaderInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyShaderInfo(params)),
   },
   {
     name: "unity_amplify_open",
@@ -2231,31 +2233,31 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.openAmplifyShader(params), null, 2),
+    handler: async (params) => formatResult(await bridge.openAmplifyShader(params)),
   },
   {
     name: "unity_amplify_list_functions",
     description: "List all Amplify Shader Functions in the project. Functions are reusable node groups (similar to Shader Graph Sub Graphs). Only available when Amplify is installed.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.listAmplifyFunctions(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listAmplifyFunctions(params)),
   },
   {
     name: "unity_amplify_get_node_types",
     description: "List all available Amplify Shader Editor node types by reflecting over the ASE assembly. Returns type names, categories, and descriptions. Requires Amplify to be installed.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyNodeTypes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyNodeTypes(params)),
   },
   {
     name: "unity_amplify_get_nodes",
     description: "Get all nodes in the currently open Amplify Shader Editor graph. Returns node IDs, types, positions, and port counts. The ASE window must be open with a shader loaded.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyGraphNodes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyGraphNodes(params)),
   },
   {
     name: "unity_amplify_get_connections",
     description: "Get all connections between nodes in the currently open Amplify Shader Editor graph. Shows which output ports connect to which input ports.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyGraphConnections(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyGraphConnections(params)),
   },
   {
     name: "unity_amplify_create_shader",
@@ -2268,7 +2270,7 @@ export const editorTools = [
       },
       required: ["path", "shaderName"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createAmplifyShader(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAmplifyShader(params)),
   },
   {
     name: "unity_amplify_add_node",
@@ -2282,7 +2284,7 @@ export const editorTools = [
       },
       required: ["nodeType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addAmplifyNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addAmplifyNode(params)),
   },
   {
     name: "unity_amplify_remove_node",
@@ -2294,7 +2296,7 @@ export const editorTools = [
       },
       required: ["nodeId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeAmplifyNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeAmplifyNode(params)),
   },
   {
     name: "unity_amplify_connect",
@@ -2309,7 +2311,7 @@ export const editorTools = [
       },
       required: ["outputNodeId", "outputPortId", "inputNodeId", "inputPortId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.connectAmplifyNodes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.connectAmplifyNodes(params)),
   },
   {
     name: "unity_amplify_disconnect",
@@ -2323,7 +2325,7 @@ export const editorTools = [
       },
       required: ["nodeId", "portId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.disconnectAmplifyNodes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.disconnectAmplifyNodes(params)),
   },
   {
     name: "unity_amplify_node_info",
@@ -2335,7 +2337,7 @@ export const editorTools = [
       },
       required: ["nodeId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyNodeInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyNodeInfo(params)),
   },
   {
     name: "unity_amplify_set_node_property",
@@ -2349,7 +2351,7 @@ export const editorTools = [
       },
       required: ["nodeId", "propertyName", "value"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setAmplifyNodeProperty(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setAmplifyNodeProperty(params)),
   },
   {
     name: "unity_amplify_move_node",
@@ -2363,7 +2365,7 @@ export const editorTools = [
       },
       required: ["nodeId", "x", "y"],
     },
-    handler: async (params) => JSON.stringify(await bridge.moveAmplifyNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.moveAmplifyNode(params)),
   },
   {
     name: "unity_amplify_save",
@@ -2374,7 +2376,7 @@ export const editorTools = [
         path: { type: "string", description: "Optional asset path to save to (e.g. 'Assets/Shaders/MyShader.shader'). Only needed if the shader has never been saved before." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.saveAmplifyGraph(params), null, 2),
+    handler: async (params) => formatResult(await bridge.saveAmplifyGraph(params)),
   },
   {
     name: "unity_amplify_close",
@@ -2385,7 +2387,7 @@ export const editorTools = [
         save: { type: "boolean", description: "Save the graph before closing (default: true)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.closeAmplifyEditor(params), null, 2),
+    handler: async (params) => formatResult(await bridge.closeAmplifyEditor(params)),
   },
   {
     name: "unity_amplify_create_from_template",
@@ -2399,7 +2401,7 @@ export const editorTools = [
       },
       required: ["path", "shaderName", "template"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createAmplifyFromTemplate(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createAmplifyFromTemplate(params)),
   },
   {
     name: "unity_amplify_focus_node",
@@ -2413,13 +2415,13 @@ export const editorTools = [
       },
       required: ["nodeId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.focusAmplifyNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.focusAmplifyNode(params)),
   },
   {
     name: "unity_amplify_master_node_info",
     description: "Get detailed information about the master/output node of the currently open Amplify shader graph, including all its input ports and properties.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getAmplifyMasterNodeInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getAmplifyMasterNodeInfo(params)),
   },
   {
     name: "unity_amplify_disconnect_all",
@@ -2431,7 +2433,7 @@ export const editorTools = [
       },
       required: ["nodeId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.disconnectAllAmplifyNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.disconnectAllAmplifyNode(params)),
   },
   {
     name: "unity_amplify_duplicate_node",
@@ -2445,7 +2447,7 @@ export const editorTools = [
       },
       required: ["nodeId"],
     },
-    handler: async (params) => JSON.stringify(await bridge.duplicateAmplifyNode(params), null, 2),
+    handler: async (params) => formatResult(await bridge.duplicateAmplifyNode(params)),
   },
 
   // â”€â”€â”€ Search & Find â”€â”€â”€
@@ -2461,7 +2463,7 @@ export const editorTools = [
       },
       required: ["componentType"],
     },
-    handler: async (params) => JSON.stringify(await bridge.findByComponent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findByComponent(params)),
   },
   {
     name: "unity_search_by_tag",
@@ -2474,7 +2476,7 @@ export const editorTools = [
       },
       required: ["tag"],
     },
-    handler: async (params) => JSON.stringify(await bridge.findByTag(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findByTag(params)),
   },
   {
     name: "unity_search_by_layer",
@@ -2487,7 +2489,7 @@ export const editorTools = [
       },
       required: ["layer"],
     },
-    handler: async (params) => JSON.stringify(await bridge.findByLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findByLayer(params)),
   },
   {
     name: "unity_search_by_name",
@@ -2502,7 +2504,7 @@ export const editorTools = [
       },
       required: ["name"],
     },
-    handler: async (params) => JSON.stringify(await bridge.findByName(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findByName(params)),
   },
   {
     name: "unity_search_by_shader",
@@ -2515,7 +2517,7 @@ export const editorTools = [
       },
       required: ["shader"],
     },
-    handler: async (params) => JSON.stringify(await bridge.findByShader(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findByShader(params)),
   },
   {
     name: "unity_search_assets",
@@ -2529,7 +2531,7 @@ export const editorTools = [
         maxResults: { type: "number", description: "Maximum results to return (default: 100)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.searchAssets(params), null, 2),
+    handler: async (params) => formatResult(await bridge.searchAssets(params)),
   },
   {
     name: "unity_search_missing_references",
@@ -2541,13 +2543,13 @@ export const editorTools = [
         limit: { type: "number", description: "Maximum results to return (default: 500)." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.findMissingReferences(params), null, 2),
+    handler: async (params) => formatResult(await bridge.findMissingReferences(params)),
   },
   {
     name: "unity_scene_stats",
     description: "Get comprehensive scene statistics: total objects, vertices, triangles, lights, cameras, colliders, and top component types.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getSceneStats(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getSceneStats(params)),
   },
 
   // â”€â”€â”€ Project Settings â”€â”€â”€
@@ -2555,7 +2557,7 @@ export const editorTools = [
     name: "unity_settings_quality",
     description: "Get current quality settings: level, shadows, anti-aliasing, LOD bias, vsync, and all quality levels available.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getQualitySettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getQualitySettings(params)),
   },
   {
     name: "unity_settings_set_quality_level",
@@ -2567,13 +2569,13 @@ export const editorTools = [
       },
       required: ["level"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setQualityLevel(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setQualityLevel(params)),
   },
   {
     name: "unity_settings_physics",
     description: "Get physics settings: gravity, solver iterations, sleep threshold, contact offset, bounce threshold.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getPhysicsSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPhysicsSettings(params)),
   },
   {
     name: "unity_settings_set_physics",
@@ -2589,13 +2591,13 @@ export const editorTools = [
         queriesHitTriggers: { type: "boolean", description: "Whether raycasts hit trigger colliders" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setPhysicsSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setPhysicsSettings(params)),
   },
   {
     name: "unity_settings_time",
     description: "Get time settings: fixedDeltaTime, maximumDeltaTime, timeScale.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getTimeSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTimeSettings(params)),
   },
   {
     name: "unity_settings_set_time",
@@ -2608,13 +2610,13 @@ export const editorTools = [
         timeScale: { type: "number", description: "Time scale (1 = normal, 0.5 = half speed, 2 = double speed)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setTimeSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTimeSettings(params)),
   },
   {
     name: "unity_settings_player",
     description: "Get player settings: company name, product name, version, color space, scripting backend, target architecture.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getPlayerSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPlayerSettings(params)),
   },
   {
     name: "unity_settings_set_player",
@@ -2628,13 +2630,13 @@ export const editorTools = [
         runInBackground: { type: "boolean", description: "Run in background when unfocused" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setPlayerSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setPlayerSettings(params)),
   },
   {
     name: "unity_settings_render_pipeline",
     description: "Get information about the current render pipeline (Built-in, URP, HDRP).",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getRenderPipelineInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getRenderPipelineInfo(params)),
   },
 
   // â”€â”€â”€ Undo â”€â”€â”€
@@ -2642,19 +2644,19 @@ export const editorTools = [
     name: "unity_undo",
     description: "Undo the last operation in Unity Editor.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.performUndo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.performUndo(params)),
   },
   {
     name: "unity_redo",
     description: "Redo the last undone operation in Unity Editor.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.performRedo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.performRedo(params)),
   },
   {
     name: "unity_undo_history",
     description: "Get information about the current undo group.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getUndoHistory(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getUndoHistory(params)),
   },
   {
     name: "unity_undo_clear",
@@ -2665,7 +2667,7 @@ export const editorTools = [
         objectPath: { type: "string", description: "Optional: clear undo only for this GameObject. If omitted, clears all." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.clearUndo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.clearUndo(params)),
   },
 
   // â”€â”€â”€ Screenshot / Scene View â”€â”€â”€
@@ -2679,7 +2681,7 @@ export const editorTools = [
         superSize: { type: "number", description: "Resolution multiplier (1 = normal, 2 = 2x, 4 = 4x)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.captureGameView(params), null, 2),
+    handler: async (params) => formatResult(await bridge.captureGameView(params)),
   },
   {
     name: "unity_screenshot_scene",
@@ -2692,13 +2694,13 @@ export const editorTools = [
         height: { type: "number", description: "Image height (default: 1080)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.captureSceneView(params), null, 2),
+    handler: async (params) => formatResult(await bridge.captureSceneView(params)),
   },
   {
     name: "unity_sceneview_info",
     description: "Get Scene View camera info: pivot position, rotation, zoom, orthographic mode, 2D mode.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getSceneViewInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getSceneViewInfo(params)),
   },
   {
     name: "unity_sceneview_set_camera",
@@ -2716,7 +2718,7 @@ export const editorTools = [
         frameSelected: { type: "boolean", description: "Frame the currently selected object" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setSceneViewCamera(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setSceneViewCamera(params)),
   },
 
   // â”€â”€â”€ Graphics & Visuals â”€â”€â”€
@@ -2745,12 +2747,12 @@ export const editorTools = [
     },
     handler: async (params) => {
       const result = await bridge.captureAssetPreview(params);
-      if (result.error) return JSON.stringify(result, null, 2);
+      if (result.error) return formatResult(result);
       const metadata = { ...result };
       delete metadata.base64;
       return [
         { type: "image", data: result.base64, mimeType: "image/png" },
-        { type: "text", text: JSON.stringify(metadata, null, 2) },
+        { type: "text", text: formatResult(metadata) },
       ];
     },
   },
@@ -2773,11 +2775,11 @@ export const editorTools = [
     },
     handler: async (params) => {
       const result = await bridge.captureSceneViewGraphics(params);
-      if (result.error) return JSON.stringify(result, null, 2);
+      if (result.error) return formatResult(result);
       // Bridge wraps response: { success, data: { success, base64 } }
       const imageData = result.data?.base64 || result.base64;
       if (!imageData || typeof imageData !== "string") {
-        return JSON.stringify({ error: "Scene capture returned no image data", ...result }, null, 2);
+        return formatResult({ error: "Scene capture returned no image data", ...result });
       }
       const metadata = { ...result };
       delete metadata.base64;
@@ -2785,7 +2787,7 @@ export const editorTools = [
       const b64 = imageData.replace(/^data:image\/\w+;base64,/, "");
       return [
         { type: "image", data: b64, mimeType: "image/png" },
-        { type: "text", text: JSON.stringify(metadata, null, 2) },
+        { type: "text", text: formatResult(metadata) },
       ];
     },
   },
@@ -2813,11 +2815,11 @@ export const editorTools = [
     },
     handler: async (params) => {
       const result = await bridge.captureGameViewGraphics(params);
-      if (result.error) return JSON.stringify(result, null, 2);
+      if (result.error) return formatResult(result);
       // Bridge wraps response: { success, data: { success, base64 } }
       const imageData = result.data?.base64 || result.base64;
       if (!imageData || typeof imageData !== "string") {
-        return JSON.stringify({ error: "Game capture returned no image data", ...result }, null, 2);
+        return formatResult({ error: "Game capture returned no image data", ...result });
       }
       const metadata = { ...result };
       delete metadata.base64;
@@ -2825,7 +2827,7 @@ export const editorTools = [
       const b64 = imageData.replace(/^data:image\/\w+;base64,/, "");
       return [
         { type: "image", data: b64, mimeType: "image/png" },
-        { type: "text", text: JSON.stringify(metadata, null, 2) },
+        { type: "text", text: formatResult(metadata) },
       ];
     },
   },
@@ -2868,12 +2870,12 @@ export const editorTools = [
     },
     handler: async (params) => {
       const result = await bridge.renderPrefabPreview(params);
-      if (result.error) return JSON.stringify(result, null, 2);
+      if (result.error) return formatResult(result);
       const metadata = { ...result };
       delete metadata.base64;
       return [
         { type: "image", data: result.base64, mimeType: "image/png" },
-        { type: "text", text: JSON.stringify(metadata, null, 2) },
+        { type: "text", text: formatResult(metadata) },
       ];
     },
   },
@@ -2897,7 +2899,7 @@ export const editorTools = [
       },
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.getMeshInfo(params), null, 2),
+      formatResult(await bridge.getMeshInfo(params)),
   },
   {
     name: "unity_graphics_material_info",
@@ -2930,16 +2932,16 @@ export const editorTools = [
     },
     handler: async (params) => {
       const result = await bridge.getMaterialInfo(params);
-      if (result.error) return JSON.stringify(result, null, 2);
+      if (result.error) return formatResult(result);
       if (result.base64) {
         const metadata = { ...result };
         delete metadata.base64;
         return [
           { type: "image", data: result.base64, mimeType: "image/png" },
-          { type: "text", text: JSON.stringify(metadata, null, 2) },
+          { type: "text", text: formatResult(metadata) },
         ];
       }
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -2964,16 +2966,16 @@ export const editorTools = [
     },
     handler: async (params) => {
       const result = await bridge.getTextureInfoGraphics(params);
-      if (result.error) return JSON.stringify(result, null, 2);
+      if (result.error) return formatResult(result);
       if (result.base64) {
         const metadata = { ...result };
         delete metadata.base64;
         return [
           { type: "image", data: result.base64, mimeType: "image/png" },
-          { type: "text", text: JSON.stringify(metadata, null, 2) },
+          { type: "text", text: formatResult(metadata) },
         ];
       }
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -2991,7 +2993,7 @@ export const editorTools = [
       required: ["objectPath"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.getRendererInfo(params), null, 2),
+      formatResult(await bridge.getRendererInfo(params)),
   },
   {
     name: "unity_graphics_lighting_summary",
@@ -3008,7 +3010,7 @@ export const editorTools = [
       },
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.getLightingSummary(params), null, 2),
+      formatResult(await bridge.getLightingSummary(params)),
   },
 
   // â”€â”€â”€ Terrain â”€â”€â”€
@@ -3027,7 +3029,7 @@ export const editorTools = [
         dataPath: { type: "string", description: "Path to save terrain data asset (default: Assets/TerrainName_Data.asset)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createTerrain(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createTerrain(params)),
   },
   {
     name: "unity_terrain_info",
@@ -3038,7 +3040,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name. If omitted, uses the active terrain." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getTerrainInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTerrainInfo(params)),
   },
   {
     name: "unity_terrain_set_height",
@@ -3054,7 +3056,7 @@ export const editorTools = [
       },
       required: ["x", "z", "height"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTerrainHeight(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTerrainHeight(params)),
   },
   {
     name: "unity_terrain_flatten",
@@ -3066,7 +3068,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.flattenTerrain(params), null, 2),
+    handler: async (params) => formatResult(await bridge.flattenTerrain(params)),
   },
   {
     name: "unity_terrain_add_layer",
@@ -3082,7 +3084,7 @@ export const editorTools = [
       },
       required: ["texturePath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addTerrainLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addTerrainLayer(params)),
   },
   {
     name: "unity_terrain_get_height",
@@ -3096,13 +3098,13 @@ export const editorTools = [
       },
       required: ["worldX", "worldZ"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getTerrainHeight(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTerrainHeight(params)),
   },
   {
     name: "unity_terrain_list",
     description: "List all terrains in the scene with their names, positions, sizes, and basic info.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.listTerrains(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listTerrains(params)),
   },
   {
     name: "unity_terrain_raise_lower",
@@ -3119,7 +3121,7 @@ export const editorTools = [
       },
       required: ["x", "z", "delta"],
     },
-    handler: async (params) => JSON.stringify(await bridge.raiseLowerTerrainHeight(params), null, 2),
+    handler: async (params) => formatResult(await bridge.raiseLowerTerrainHeight(params)),
   },
   {
     name: "unity_terrain_smooth",
@@ -3135,7 +3137,7 @@ export const editorTools = [
       },
       required: ["x", "z"],
     },
-    handler: async (params) => JSON.stringify(await bridge.smoothTerrainHeight(params), null, 2),
+    handler: async (params) => formatResult(await bridge.smoothTerrainHeight(params)),
   },
   {
     name: "unity_terrain_noise",
@@ -3151,7 +3153,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setTerrainNoise(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTerrainNoise(params)),
   },
   {
     name: "unity_terrain_set_heights_region",
@@ -3166,7 +3168,7 @@ export const editorTools = [
       },
       required: ["xBase", "yBase", "heights"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTerrainHeightsRegion(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTerrainHeightsRegion(params)),
   },
   {
     name: "unity_terrain_get_heights_region",
@@ -3182,7 +3184,7 @@ export const editorTools = [
       },
       required: ["xBase", "yBase", "width", "height"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getTerrainHeightsRegion(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTerrainHeightsRegion(params)),
   },
   {
     name: "unity_terrain_remove_layer",
@@ -3195,7 +3197,7 @@ export const editorTools = [
       },
       required: ["layerIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeTerrainLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeTerrainLayer(params)),
   },
   {
     name: "unity_terrain_paint_layer",
@@ -3213,7 +3215,7 @@ export const editorTools = [
       },
       required: ["x", "z", "layerIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.paintTerrainLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.paintTerrainLayer(params)),
   },
   {
     name: "unity_terrain_fill_layer",
@@ -3226,7 +3228,7 @@ export const editorTools = [
       },
       required: ["layerIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.fillTerrainLayer(params), null, 2),
+    handler: async (params) => formatResult(await bridge.fillTerrainLayer(params)),
   },
   {
     name: "unity_terrain_add_tree_prototype",
@@ -3240,7 +3242,7 @@ export const editorTools = [
       },
       required: ["prefabPath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addTerrainTreePrototype(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addTerrainTreePrototype(params)),
   },
   {
     name: "unity_terrain_remove_tree_prototype",
@@ -3253,7 +3255,7 @@ export const editorTools = [
       },
       required: ["prototypeIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeTerrainTreePrototype(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeTerrainTreePrototype(params)),
   },
   {
     name: "unity_terrain_place_trees",
@@ -3277,7 +3279,7 @@ export const editorTools = [
       },
       required: ["prototypeIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.placeTerrainTrees(params), null, 2),
+    handler: async (params) => formatResult(await bridge.placeTerrainTrees(params)),
   },
   {
     name: "unity_terrain_clear_trees",
@@ -3289,7 +3291,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.clearTerrainTrees(params), null, 2),
+    handler: async (params) => formatResult(await bridge.clearTerrainTrees(params)),
   },
   {
     name: "unity_terrain_get_tree_instances",
@@ -3301,7 +3303,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getTerrainTreeInstances(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTerrainTreeInstances(params)),
   },
   {
     name: "unity_terrain_add_detail_prototype",
@@ -3320,7 +3322,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.addTerrainDetailPrototype(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addTerrainDetailPrototype(params)),
   },
   {
     name: "unity_terrain_paint_detail",
@@ -3337,7 +3339,7 @@ export const editorTools = [
       },
       required: ["x", "z", "detailIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.paintTerrainDetail(params), null, 2),
+    handler: async (params) => formatResult(await bridge.paintTerrainDetail(params)),
   },
   {
     name: "unity_terrain_scatter_detail",
@@ -3353,7 +3355,7 @@ export const editorTools = [
       },
       required: ["detailIndex"],
     },
-    handler: async (params) => JSON.stringify(await bridge.scatterTerrainDetail(params), null, 2),
+    handler: async (params) => formatResult(await bridge.scatterTerrainDetail(params)),
   },
   {
     name: "unity_terrain_clear_detail",
@@ -3365,7 +3367,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.clearTerrainDetail(params), null, 2),
+    handler: async (params) => formatResult(await bridge.clearTerrainDetail(params)),
   },
   {
     name: "unity_terrain_set_holes",
@@ -3380,7 +3382,7 @@ export const editorTools = [
       },
       required: ["xBase", "yBase", "holes"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTerrainHoles(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTerrainHoles(params)),
   },
   {
     name: "unity_terrain_set_settings",
@@ -3402,7 +3404,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setTerrainSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTerrainSettings(params)),
   },
   {
     name: "unity_terrain_resize",
@@ -3417,7 +3419,7 @@ export const editorTools = [
         name: { type: "string", description: "Terrain name (optional)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.resizeTerrain(params), null, 2),
+    handler: async (params) => formatResult(await bridge.resizeTerrain(params)),
   },
   {
     name: "unity_terrain_create_grid",
@@ -3436,7 +3438,7 @@ export const editorTools = [
       },
       required: ["rows", "cols"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createTerrainGrid(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createTerrainGrid(params)),
   },
   {
     name: "unity_terrain_set_neighbors",
@@ -3452,7 +3454,7 @@ export const editorTools = [
       },
       required: ["terrain"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTerrainNeighbors(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTerrainNeighbors(params)),
   },
   {
     name: "unity_terrain_import_heightmap",
@@ -3467,7 +3469,7 @@ export const editorTools = [
       },
       required: ["filePath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.importTerrainHeightmap(params), null, 2),
+    handler: async (params) => formatResult(await bridge.importTerrainHeightmap(params)),
   },
   {
     name: "unity_terrain_export_heightmap",
@@ -3481,7 +3483,7 @@ export const editorTools = [
       },
       required: ["filePath"],
     },
-    handler: async (params) => JSON.stringify(await bridge.exportTerrainHeightmap(params), null, 2),
+    handler: async (params) => formatResult(await bridge.exportTerrainHeightmap(params)),
   },
   {
     name: "unity_terrain_get_steepness",
@@ -3495,7 +3497,7 @@ export const editorTools = [
       },
       required: ["worldX", "worldZ"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getTerrainSteepness(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTerrainSteepness(params)),
   },
 
   // â”€â”€â”€ Particle System â”€â”€â”€
@@ -3517,7 +3519,7 @@ export const editorTools = [
         gravityModifier: { type: "number", description: "Gravity multiplier" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createParticleSystem(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createParticleSystem(params)),
   },
   {
     name: "unity_particle_info",
@@ -3529,7 +3531,7 @@ export const editorTools = [
         instanceId: { type: "number", description: "Instance ID (alternative)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.getParticleSystemInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getParticleSystemInfo(params)),
   },
   {
     name: "unity_particle_set_main",
@@ -3547,7 +3549,7 @@ export const editorTools = [
         simulationSpace: { type: "string", description: "Local, World, or Custom" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setParticleMainModule(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setParticleMainModule(params)),
   },
   {
     name: "unity_particle_set_emission",
@@ -3562,7 +3564,7 @@ export const editorTools = [
         rateOverDistance: { type: "number", description: "Particles emitted per unit distance" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setParticleEmission(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setParticleEmission(params)),
   },
   {
     name: "unity_particle_set_shape",
@@ -3578,7 +3580,7 @@ export const editorTools = [
         arc: { type: "number" }, radiusThickness: { type: "number", description: "0 = emit from surface only, 1 = emit from entire volume" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.setParticleShape(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setParticleShape(params)),
   },
   {
     name: "unity_particle_playback",
@@ -3592,7 +3594,7 @@ export const editorTools = [
       },
       required: ["action"],
     },
-    handler: async (params) => JSON.stringify(await bridge.particlePlayback(params), null, 2),
+    handler: async (params) => formatResult(await bridge.particlePlayback(params)),
   },
 
   // â”€â”€â”€ ScriptableObject â”€â”€â”€
@@ -3607,7 +3609,7 @@ export const editorTools = [
       },
       required: ["type"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createScriptableObject(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createScriptableObject(params)),
   },
   {
     name: "unity_scriptableobject_info",
@@ -3619,7 +3621,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getScriptableObjectInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getScriptableObjectInfo(params)),
   },
   {
     name: "unity_scriptableobject_set_field",
@@ -3633,7 +3635,7 @@ export const editorTools = [
       },
       required: ["path", "field", "value"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setScriptableObjectField(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setScriptableObjectField(params)),
   },
   {
     name: "unity_scriptableobject_list_types",
@@ -3645,7 +3647,7 @@ export const editorTools = [
         includeEngine: { type: "boolean", description: "Include Unity engine types (default: false, project types only)" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listScriptableObjectTypes(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listScriptableObjectTypes(params)),
   },
 
   // â”€â”€â”€ Texture â”€â”€â”€
@@ -3659,7 +3661,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getTextureInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getTextureInfo(params)),
   },
   {
     name: "unity_texture_set_import",
@@ -3684,7 +3686,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTextureImportSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTextureImportSettings(params)),
   },
   {
     name: "unity_texture_reimport",
@@ -3696,7 +3698,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.reimportTexture(params), null, 2),
+    handler: async (params) => formatResult(await bridge.reimportTexture(params)),
   },
   {
     name: "unity_texture_set_sprite",
@@ -3710,7 +3712,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTextureAsSprite(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTextureAsSprite(params)),
   },
   {
     name: "unity_texture_set_normalmap",
@@ -3722,7 +3724,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setTextureAsNormalMap(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setTextureAsNormalMap(params)),
   },
 
   // â”€â”€â”€ Navigation â”€â”€â”€
@@ -3739,13 +3741,13 @@ export const editorTools = [
         agentClimb: { type: "number", description: "Step height the agent can climb" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.bakeNavMesh(params), null, 2),
+    handler: async (params) => formatResult(await bridge.bakeNavMesh(params)),
   },
   {
     name: "unity_navmesh_clear",
     description: "Clear all baked NavMeshes from the scene.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.clearNavMesh(params), null, 2),
+    handler: async (params) => formatResult(await bridge.clearNavMesh(params)),
   },
   {
     name: "unity_navmesh_add_agent",
@@ -3763,7 +3765,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addNavMeshAgent(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addNavMeshAgent(params)),
   },
   {
     name: "unity_navmesh_add_obstacle",
@@ -3777,13 +3779,13 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addNavMeshObstacle(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addNavMeshObstacle(params)),
   },
   {
     name: "unity_navmesh_info",
     description: "Get NavMesh information: vertex/triangle count, agents, obstacles, agent types.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getNavMeshInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getNavMeshInfo(params)),
   },
   {
     name: "unity_navmesh_set_destination",
@@ -3800,7 +3802,7 @@ export const editorTools = [
       },
       required: ["path", "destination"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setAgentDestination(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setAgentDestination(params)),
   },
 
   // â”€â”€â”€ UI â”€â”€â”€
@@ -3815,7 +3817,7 @@ export const editorTools = [
         renderMode: { type: "string", description: "Render mode: overlay, camera, or world" },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.createCanvas(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createCanvas(params)),
   },
   {
     name: "unity_ui_create_element",
@@ -3832,13 +3834,13 @@ export const editorTools = [
       },
       required: ["type"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createUIElement(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createUIElement(params)),
   },
   {
     name: "unity_ui_info",
     description: "Get UI information: canvases, text/image/button counts.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.getUIInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getUIInfo(params)),
   },
   {
     name: "unity_ui_set_text",
@@ -3854,7 +3856,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setUIText(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setUIText(params)),
   },
   {
     name: "unity_ui_set_image",
@@ -3870,7 +3872,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setUIImage(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setUIImage(params)),
   },
 
   // â”€â”€â”€ Package Manager â”€â”€â”€
@@ -3879,7 +3881,7 @@ export const editorTools = [
     name: "unity_packages_list",
     description: "List all installed Unity packages with their name, version, source, and status.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.listPackages(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listPackages(params)),
   },
   {
     name: "unity_packages_add",
@@ -3891,7 +3893,7 @@ export const editorTools = [
       },
       required: ["identifier"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addPackage(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addPackage(params)),
   },
   {
     name: "unity_packages_remove",
@@ -3903,7 +3905,7 @@ export const editorTools = [
       },
       required: ["name"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removePackage(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removePackage(params)),
   },
   {
     name: "unity_packages_search",
@@ -3915,7 +3917,7 @@ export const editorTools = [
       },
       required: ["query"],
     },
-    handler: async (params) => JSON.stringify(await bridge.searchPackage(params), null, 2),
+    handler: async (params) => formatResult(await bridge.searchPackage(params)),
   },
   {
     name: "unity_packages_info",
@@ -3927,7 +3929,7 @@ export const editorTools = [
       },
       required: ["name"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getPackageInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPackageInfo(params)),
   },
 
   // â”€â”€â”€ Constraints & LOD â”€â”€â”€
@@ -3945,7 +3947,7 @@ export const editorTools = [
       },
       required: ["path", "type"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addConstraint(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addConstraint(params)),
   },
   {
     name: "unity_constraint_info",
@@ -3957,7 +3959,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getConstraintInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getConstraintInfo(params)),
   },
   {
     name: "unity_lod_create",
@@ -3970,7 +3972,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createLODGroup(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createLODGroup(params)),
   },
   {
     name: "unity_lod_info",
@@ -3982,7 +3984,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getLODGroupInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getLODGroupInfo(params)),
   },
 
   // â”€â”€â”€ Prefs â”€â”€â”€
@@ -3998,7 +4000,7 @@ export const editorTools = [
       },
       required: ["key"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getEditorPref(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getEditorPref(params)),
   },
   {
     name: "unity_editorprefs_set",
@@ -4012,7 +4014,7 @@ export const editorTools = [
       },
       required: ["key", "value"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setEditorPref(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setEditorPref(params)),
   },
   {
     name: "unity_editorprefs_delete",
@@ -4024,7 +4026,7 @@ export const editorTools = [
       },
       required: ["key"],
     },
-    handler: async (params) => JSON.stringify(await bridge.deleteEditorPref(params), null, 2),
+    handler: async (params) => formatResult(await bridge.deleteEditorPref(params)),
   },
   {
     name: "unity_playerprefs_get",
@@ -4037,7 +4039,7 @@ export const editorTools = [
       },
       required: ["key"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getPlayerPref(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getPlayerPref(params)),
   },
   {
     name: "unity_playerprefs_set",
@@ -4051,7 +4053,7 @@ export const editorTools = [
       },
       required: ["key", "value"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setPlayerPref(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setPlayerPref(params)),
   },
   {
     name: "unity_playerprefs_delete",
@@ -4063,13 +4065,13 @@ export const editorTools = [
       },
       required: ["key"],
     },
-    handler: async (params) => JSON.stringify(await bridge.deletePlayerPref(params), null, 2),
+    handler: async (params) => formatResult(await bridge.deletePlayerPref(params)),
   },
   {
     name: "unity_playerprefs_delete_all",
     description: "Delete ALL PlayerPrefs. Use with caution.",
     inputSchema: { type: "object", properties: {} },
-    handler: async (params) => JSON.stringify(await bridge.deleteAllPlayerPrefs(params), null, 2),
+    handler: async (params) => formatResult(await bridge.deleteAllPlayerPrefs(params)),
   },
 
   // â”€â”€â”€ Queue Management (Multi-Agent) â”€â”€â”€
@@ -4078,7 +4080,7 @@ export const editorTools = [
     description:
       "Get the current state of the multi-agent request queue: total queued requests, active agents, per-agent queue depths, and completed cache size. Useful for monitoring when multiple agents are working on the same Unity project.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.getQueueInfo(), null, 2),
+    handler: async () => formatResult(await bridge.getQueueInfo()),
   },
   {
     name: "unity_queue_ticket_status",
@@ -4095,14 +4097,14 @@ export const editorTools = [
       required: ["ticketId"],
     },
     handler: async ({ ticketId }) =>
-      JSON.stringify(await bridge.getTicketStatus(ticketId), null, 2),
+      formatResult(await bridge.getTicketStatus(ticketId)),
   },
   {
     name: "unity_agents_list",
     description:
       "List all active agent sessions connected to the AB Unity MCP bridge. Shows each agent's ID, connection time, last activity, current action, total actions count, queued/completed request counts, and average response time.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.listAgents(), null, 2),
+    handler: async () => formatResult(await bridge.listAgents()),
   },
   {
     name: "unity_agent_log",
@@ -4119,7 +4121,7 @@ export const editorTools = [
       required: ["agentId"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.getAgentLog(params), null, 2),
+      formatResult(await bridge.getAgentLog(params)),
   },
 
   // â”€â”€â”€ MPPM Scenario Management â”€â”€â”€
@@ -4129,13 +4131,13 @@ export const editorTools = [
     name: "unity_mppm_list_scenarios",
     description: "List all MPPM (Multiplayer PlayMode) scenarios in the project with details about instances and configurations.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.sendCommand("scenario/list", {}), null, 2),
+    handler: async () => formatResult(await bridge.sendCommand("scenario/list", {})),
   },
   {
     name: "unity_mppm_status",
     description: "Get the current scenario status including running state, active scenario name, and progress.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.sendCommand("scenario/status", {}), null, 2),
+    handler: async () => formatResult(await bridge.sendCommand("scenario/status", {})),
   },
   {
     name: "unity_mppm_activate_scenario",
@@ -4147,25 +4149,25 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async ({ path }) => JSON.stringify(await bridge.sendCommand("scenario/activate", { path }), null, 2),
+    handler: async ({ path }) => formatResult(await bridge.sendCommand("scenario/activate", { path })),
   },
   {
     name: "unity_mppm_start",
     description: "Start the currently active scenario.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.sendCommand("scenario/start", {}), null, 2),
+    handler: async () => formatResult(await bridge.sendCommand("scenario/start", {})),
   },
   {
     name: "unity_mppm_stop",
     description: "Stop the running scenario.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.sendCommand("scenario/stop", {}), null, 2),
+    handler: async () => formatResult(await bridge.sendCommand("scenario/stop", {})),
   },
   {
     name: "unity_mppm_info",
     description: "Get multiplayer play mode information including CurrentPlayer state, tags, and MPPM package version.",
     inputSchema: { type: "object", properties: {} },
-    handler: async () => JSON.stringify(await bridge.sendCommand("scenario/info", {}), null, 2),
+    handler: async () => formatResult(await bridge.sendCommand("scenario/info", {})),
   },
 
   // ─── Testing ───
@@ -4216,12 +4218,12 @@ export const editorTools = [
         await new Promise((r) => setTimeout(r, 2000));
         try {
           const status = await bridge.getTestJob({ jobId: result.jobId });
-          return JSON.stringify(status, null, 2);
+          return formatResult(status);
         } catch (_) {
-          return JSON.stringify(result, null, 2);
+          return formatResult(result);
         }
       }
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -4263,15 +4265,15 @@ export const editorTools = [
           lastResult = await bridge.getTestJob(params);
           const status = lastResult?.status;
           if (status === "succeeded" || status === "failed") {
-            return JSON.stringify(lastResult, null, 2);
+            return formatResult(lastResult);
           }
           // Wait 2 seconds before next poll
           await new Promise((r) => setTimeout(r, 2000));
         }
         // Timeout — return last known state
-        return JSON.stringify(lastResult || (await bridge.getTestJob(params)), null, 2);
+        return formatResult(lastResult || (await bridge.getTestJob(params)));
       }
-      return JSON.stringify(await bridge.getTestJob(params), null, 2);
+      return formatResult(await bridge.getTestJob(params));
     },
   },
   {
@@ -4297,7 +4299,7 @@ export const editorTools = [
         },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listTests(params || {}), null, 2),
+    handler: async (params) => formatResult(await bridge.listTests(params || {})),
   },
 
   // ─── Sprite Atlas ───
@@ -4313,7 +4315,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.createSpriteAtlas(params), null, 2),
+    handler: async (params) => formatResult(await bridge.createSpriteAtlas(params)),
   },
   {
     name: "unity_spriteatlas_info",
@@ -4325,7 +4327,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.getSpriteAtlasInfo(params), null, 2),
+    handler: async (params) => formatResult(await bridge.getSpriteAtlasInfo(params)),
   },
   {
     name: "unity_spriteatlas_add",
@@ -4339,7 +4341,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.addToSpriteAtlas(params), null, 2),
+    handler: async (params) => formatResult(await bridge.addToSpriteAtlas(params)),
   },
   {
     name: "unity_spriteatlas_remove",
@@ -4353,7 +4355,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.removeFromSpriteAtlas(params), null, 2),
+    handler: async (params) => formatResult(await bridge.removeFromSpriteAtlas(params)),
   },
   {
     name: "unity_spriteatlas_settings",
@@ -4373,7 +4375,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.setSpriteAtlasSettings(params), null, 2),
+    handler: async (params) => formatResult(await bridge.setSpriteAtlasSettings(params)),
   },
   {
     name: "unity_spriteatlas_delete",
@@ -4385,7 +4387,7 @@ export const editorTools = [
       },
       required: ["path"],
     },
-    handler: async (params) => JSON.stringify(await bridge.deleteSpriteAtlas(params), null, 2),
+    handler: async (params) => formatResult(await bridge.deleteSpriteAtlas(params)),
   },
   {
     name: "unity_spriteatlas_list",
@@ -4396,6 +4398,6 @@ export const editorTools = [
         folder: { type: "string", description: "Folder to search in (e.g. 'Assets/Atlases'). Omit to search entire project." },
       },
     },
-    handler: async (params) => JSON.stringify(await bridge.listSpriteAtlases(params), null, 2),
+    handler: async (params) => formatResult(await bridge.listSpriteAtlases(params)),
   },
 ];

--- a/src/tools/hub-tools.js
+++ b/src/tools/hub-tools.js
@@ -1,6 +1,8 @@
 // AnkleBreaker Unity MCP — Tool definitions for Unity Hub operations
 import * as hub from "../unity-hub.js";
 
+import { formatResult } from "../response-format.js";
+
 export const hubTools = [
   {
     name: "unity_hub_list_editors",
@@ -11,7 +13,7 @@ export const hubTools = [
     },
     handler: async () => {
       const result = await hub.listInstalledEditors();
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -23,7 +25,7 @@ export const hubTools = [
     },
     handler: async () => {
       const result = await hub.listAvailableReleases();
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -43,7 +45,7 @@ export const hubTools = [
     },
     handler: async ({ version, modules }) => {
       const result = await hub.installEditor(version, modules || []);
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -63,7 +65,7 @@ export const hubTools = [
     },
     handler: async ({ version, modules }) => {
       const result = await hub.installModules(version, modules);
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -75,7 +77,7 @@ export const hubTools = [
     },
     handler: async () => {
       const result = await hub.getInstallPath();
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
   {
@@ -90,7 +92,7 @@ export const hubTools = [
     },
     handler: async ({ path }) => {
       const result = await hub.setInstallPath(path);
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
 ];

--- a/src/tools/instance-tools.js
+++ b/src/tools/instance-tools.js
@@ -8,6 +8,8 @@ import {
   autoSelectInstance,
 } from "../instance-discovery.js";
 
+import { formatResult } from "../response-format.js";
+
 export const instanceTools = [
   {
     name: "unity_list_instances",
@@ -56,7 +58,7 @@ export const instanceTools = [
         result.message = `Found ${instances.length} Unity instance(s). Currently targeting: ${selected.projectName} (port ${selected.port})`;
       }
 
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
 
@@ -83,15 +85,12 @@ export const instanceTools = [
     },
     handler: async ({ port }) => {
       if (!port || typeof port !== "number") {
-        return JSON.stringify(
+        return formatResult(
           {
             success: false,
             error:
               "Port number is required. Use unity_list_instances to see available instances.",
-          },
-          null,
-          2
-        );
+          });
       }
 
       const result = await selectInstance(port);
@@ -108,7 +107,7 @@ export const instanceTools = [
         };
       }
 
-      return JSON.stringify(result, null, 2);
+      return formatResult(result);
     },
   },
 ];

--- a/src/tools/uma-tools.js
+++ b/src/tools/uma-tools.js
@@ -3,6 +3,8 @@
 // The C# side is wrapped in #if UMA_INSTALLED - calls will return an error if UMA is absent.
 import * as bridge from "../uma-bridge.js";
 
+import { formatResult } from "../response-format.js";
+
 export const umaTools = [
   {
     name: "unity_uma_inspect_fbx",
@@ -20,7 +22,7 @@ export const umaTools = [
       required: ["fbxPath"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaInspectFbx(params), null, 2),
+      formatResult(await bridge.umaInspectFbx(params)),
   },
   {
     name: "unity_uma_create_slot",
@@ -59,7 +61,7 @@ export const umaTools = [
       required: ["fbxPath", "smrName", "slotName", "outputFolder", "umaMaterialPath"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaCreateSlot(params), null, 2),
+      formatResult(await bridge.umaCreateSlot(params)),
   },
   {
     name: "unity_uma_create_overlay",
@@ -90,7 +92,7 @@ export const umaTools = [
       required: ["overlayName", "outputFolder", "umaMaterialPath", "textures"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaCreateOverlay(params), null, 2),
+      formatResult(await bridge.umaCreateOverlay(params)),
   },
   {
     name: "unity_uma_create_wardrobe_recipe",
@@ -174,7 +176,7 @@ export const umaTools = [
       required: ["recipeName", "outputFolder", "wardrobeSlot", "compatibleRaces", "slots"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaCreateWardrobeRecipe(params), null, 2),
+      formatResult(await bridge.umaCreateWardrobeRecipe(params)),
   },
   {
     name: "unity_uma_register_assets",
@@ -196,7 +198,7 @@ export const umaTools = [
       },
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaRegisterAssets(params), null, 2),
+      formatResult(await bridge.umaRegisterAssets(params)),
   },
   {
     name: "unity_uma_list_global_library",
@@ -216,7 +218,7 @@ export const umaTools = [
       },
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaListGlobalLibrary(params), null, 2),
+      formatResult(await bridge.umaListGlobalLibrary(params)),
   },
   {
     name: "unity_uma_list_wardrobe_slots",
@@ -233,7 +235,7 @@ export const umaTools = [
       required: ["raceName"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaListWardrobeSlots(params), null, 2),
+      formatResult(await bridge.umaListWardrobeSlots(params)),
   },
   {
     name: "unity_uma_list_uma_materials",
@@ -244,7 +246,7 @@ export const umaTools = [
       properties: {},
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaListUMAMaterials(params), null, 2),
+      formatResult(await bridge.umaListUMAMaterials(params)),
   },
   {
     name: "unity_uma_get_project_config",
@@ -255,7 +257,7 @@ export const umaTools = [
       properties: {},
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaGetProjectConfig(params), null, 2),
+      formatResult(await bridge.umaGetProjectConfig(params)),
   },
   {
     name: "unity_uma_verify_recipe",
@@ -274,7 +276,7 @@ export const umaTools = [
       required: ["recipePath"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaVerifyRecipe(params), null, 2),
+      formatResult(await bridge.umaVerifyRecipe(params)),
   },
   {
     name: "unity_uma_rebuild_global_library",
@@ -299,7 +301,7 @@ export const umaTools = [
       },
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaRebuildGlobalLibrary(params), null, 2),
+      formatResult(await bridge.umaRebuildGlobalLibrary(params)),
   },
   {
     name: "unity_uma_create_wardrobe_from_fbx",
@@ -377,7 +379,7 @@ export const umaTools = [
       required: ["fbxPath", "outputFolder", "wardrobeSlot", "umaMaterialPath", "variants"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaCreateWardrobeFromFbx(params), null, 2),
+      formatResult(await bridge.umaCreateWardrobeFromFbx(params)),
   },
   {
     name: "unity_uma_wardrobe_equip",
@@ -414,7 +416,7 @@ export const umaTools = [
       required: ["gameObjectPath", "wardrobeSlot"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaWardrobeEquip(params), null, 2),
+      formatResult(await bridge.umaWardrobeEquip(params)),
   },
   {
     name: "unity_uma_edit_race",
@@ -519,7 +521,7 @@ export const umaTools = [
       },
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaEditRace(params), null, 2),
+      formatResult(await bridge.umaEditRace(params)),
   },
   {
     name: "unity_uma_create_race",
@@ -622,6 +624,6 @@ export const umaTools = [
       required: ["raceName"],
     },
     handler: async (params) =>
-      JSON.stringify(await bridge.umaCreateRace(params), null, 2),
+      formatResult(await bridge.umaCreateRace(params)),
   },
 ];

--- a/tests/response-format.test.mjs
+++ b/tests/response-format.test.mjs
@@ -1,0 +1,43 @@
+// Unit cases for WIN A keystone: isErrorResult / looksLikeErrorObject.
+// Forward-ported from branch agent-contract-wins onto main (2026-07-02).
+// The Unity bridge returns HTTP 200 on logical failure; these helpers let the
+// Node seam set MCP isError for every existing Unity-side error shape.
+import assert from "node:assert/strict";
+import { isErrorResult, looksLikeErrorObject } from "../src/response-format.js";
+
+const cases = [
+  // label, input, expected isErrorResult
+  ["legacy {error}", { error: "boom" }, true],
+  ["{success:false}", { success: false }, true],
+  ["queue-wrapped {success:true,data:{error}}", { success: true, data: { error: "x" } }, true],
+  ["factory {ok:false,error}", { ok: false, error: { code: "E", message: "m" } }, true],
+  ["{data:{error}} no success claim", { data: { error: "x" } }, true],
+  ["self-declared {ok:true}", { ok: true, value: 1 }, false],
+  ["self-declared {success:true}", { success: true, value: 1 }, false],
+  ["{success:true,error:''} JsonUtility empty", { success: true, error: "" }, false],
+  ["JSON string error", '{"error":"boom"}', true],
+  ["JSON string success", '{"success":true}', false],
+  ["prose error string", "Error: something failed", true],
+  ["plain success string", "Done.", false],
+  ["content-block array", [{ type: "image", data: "..." }], false],
+];
+
+let pass = 0;
+const failures = [];
+for (const [label, input, expected] of cases) {
+  const got = isErrorResult(input);
+  try {
+    assert.equal(got, expected);
+    pass++;
+  } catch {
+    failures.push(`FAIL: ${label} — expected ${expected}, got ${got}`);
+  }
+}
+
+// Spot-check the lower-level predicate too.
+assert.equal(looksLikeErrorObject({ ok: false }), true);
+assert.equal(looksLikeErrorObject({ ok: true, error: "" }), false);
+
+for (const f of failures) console.error(f);
+console.log(`response-format isErrorResult: ${pass}/${cases.length} passed`);
+process.exit(failures.length === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Forward-ports three isolated AnkleBreaker MCP wins onto **v2.28.2** (`origin/main` 66ff10c). Each is independent, mechanical, and verified. Branch is 3 ahead / 0 behind main — clean linear stack.

### WIN A — `isError` on logical failures (`e326568`)
Adds `src/response-format.js` (`isErrorResult` / `looksLikeErrorObject`) and wires `isError` at the `CallTool` return seam in `src/index.js`. The Unity bridge returns HTTP 200 for *logical* failures, and handlers return several error shapes (`{error}`, `{success:false}`, queue-wrapped `{success:true, data:{error}}`, and the `{ok:false, error:{…}}` envelope) — none of which set the MCP `isError` flag, so a client reads a logical failure as success. This sets `isError` for every existing error shape with **zero C# edits**. Tests: `tests/response-format.test.mjs` — 13/13.

### WIN F — tool-tiers `inputSchema` echo + did-you-mean (`b51755e`)
`src/tool-tiers.js`: echoes `inputSchema` in the category branch and adds a Levenshtein "did you mean" suggestion on unknown tool names. Clean cherry-pick of `e51295a`, reusing `formatResult`.

### WIN N — compact JSON responses by default (`501ad48`)
Routes all **341** `JSON.stringify(x, null, 2)` response sites across 5 tool files (`editor-tools` 316, `uma-tools` 15, `hub-tools` 6, `instance-tools` 3, `context-tools` 1) through the shared `formatResult()` helper — compact by default, `UNITY_MCP_PRETTY_JSON=1` restores indentation for debugging. The C# bridge (MiniJson) already sends compact over HTTP; this reverts an unnecessary Node-side re-pretty step. **~44% byte reduction** on nested payloads (deep scene hierarchies, large asset lists — the responses that dominate token cost). No behavior change: `JSON.parse` in the isError seam is whitespace-insensitive, so error detection is unaffected.

## Verification
- `node --check` on all touched files — pass
- Runtime import — all 5 tool modules link, `formatResult` path resolves from each
- Compact/pretty toggle confirmed (default compact; `UNITY_MCP_PRETTY_JSON=1` pretty)
- `tests/response-format.test.mjs` — 13/13
- Zero `JSON.stringify` remaining in `src/tools/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
