### PR TITLE
feat(capabilities): protocol handshake + graceful batch-wire degrade

### DIFF
--- a/docs/capability-handshake-followups.md
+++ b/docs/capability-handshake-followups.md
@@ -1,0 +1,35 @@
+# Capability Handshake — Follow-up TODOs
+
+Captured 2026-07-12 alongside the server↔plugin capability-negotiation work
+(branch `feat/capability-handshake`). These are deliberately **not built now**.
+Rationale + evidence: `knowledge/research/2026-07-12-vet-unity-ml-agents.md`
+(in the DevCrow workspace) and the evidence-over-agreement gate that scoped the
+handshake down to its right-sized form.
+
+## 1. WIN K — derive routes from the switch (`[MCPCommand]` + assembly scan)
+The durable fix for capability drift. Today `_meta/routes` (plugin
+`MCPBridgeServer.GetRegisteredRoutes`) is a hand-maintained list already stale
+versus the actual `RouteRequest` switch. Verified mismatches: it advertises
+`script/execute-code` (real case `editor/execute-code`), `material/create`
+(real `asset/create-material`), `build/build` (real `build/start`), `navmesh/*`
+(real `navigation/*`), plus missing families (`prefab-asset/*`, `editorprefs/*`,
+`scenario/*`, `uma/*`, …). A `[MCPCommand("cat/action")]` attribute + one
+assembly scan that builds the route table from the switch deletes the drift
+class entirely — and is the cleanest on-ramp to official Unity MCP's `[McpTool]`.
+Do this before any official-MCP migration. (Already parked as "WIN K" in the
+2026-06-29 AnkleBreaker transferable-wins plan.)
+
+## 2. Statics-reset factory for the plugin's static bridge
+Ref: ml-agents `CommunicatorFactory.cs` —
+`[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]`
+resets static state on load. The plugin's `MCPBridgeServer` is a static
+singleton; static state can survive enter-play-mode and leak stale server/socket
+state (the footgun that bites any Unity tool with a static singleton bridge).
+Add a statics-reset hook so entering play mode starts clean.
+
+## 3. Pin publish-workflow GitHub Actions to commit SHAs + OIDC
+Both repos (`AnkleBreaker-Studio/unity-mcp-server` +
+`AnkleBreaker-Studio/unity-mcp-plugin`). The ml-agents vet flagged unpinned
+actions (`@main` / `@master`) + token-based publish as the anti-pattern. Pin
+every action to a commit SHA and move publish to OIDC trusted publishing (no
+long-lived registry token).

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -1,0 +1,148 @@
+// AnkleBreaker Unity MCP — server↔plugin capability negotiation (drift resilience).
+//
+// The Node server and the Unity plugin ship on separate release trains and drift
+// (server 2.28.2 vs plugin 2.27.0 at time of writing). Before this module the two
+// never exchanged a version or feature signal: a call to a route an older plugin
+// lacks came back as `{error:"Unknown API endpoint"}` and — since WIN A — surfaced
+// as an MCP error, but with no graceful fallback and no "why".
+//
+// Pattern ported (not copied) from Unity ML-Agents' UnityRLCapabilities handshake:
+// each side advertises what it supports; a missing/older peer is detected and the
+// feature DEGRADES with one warning instead of failing. Two deliberate differences
+// from ml-agents, because this is an HTTP route bridge, not a bilateral RL protocol:
+//   1. Capability is PROVIDER-side, not symmetric. The plugin provides a route; the
+//      server consumes it. The predicate is one-sided ("does the plugin support
+//      it?"), NOT `serverCap AND pluginCap` — a symmetric AND would wrongly gate a
+//      route the plugin actually implements.
+//   2. We gate on a single monotonic `protocolVersion` int, not a hand-maintained
+//      bool map. A bool catalog would rot exactly like the plugin's already-stale
+//      `_meta/routes` list. Route existence stays the plugin's job; this file only
+//      decides "is the peer new enough for feature X, and if not, how do we cope".
+//
+// Ref: knowledge/research/2026-07-12-vet-unity-ml-agents.md
+
+/**
+ * Wire-protocol version this server speaks. Bump when the server starts REQUIRING a
+ * plugin-side behavior that older plugins can't provide. Keep in sync with the
+ * plugin's MCPCapabilities.ProtocolVersion.
+ */
+export const PROTOCOL_VERSION = 1;
+
+/**
+ * Minimum plugin `protocolVersion` required for each negotiated feature. A feature
+ * absent from this map is unknown → unsupported (fail-safe to degrade).
+ */
+export const FEATURE_MIN_PROTOCOL = {
+  // component/batch-wire — the first negotiated flag. Degrades to N single
+  // component/set-reference calls when the plugin predates it.
+  batchWire: 1,
+};
+
+/**
+ * Is the connected plugin KNOWN to support a negotiated feature?
+ * One-sided provider check: the plugin advertises `protocolVersion` in its ping
+ * response; a plugin that predates the handshake omits it → treated as 0 →
+ * unsupported. Mirrors ml-agents' "a capability the peer never mentions is false".
+ * @param {object|null} instance - selected Unity instance (from getSelectedInstance()).
+ * @param {string} feature - key in FEATURE_MIN_PROTOCOL.
+ * @returns {boolean}
+ */
+export function pluginSupports(instance, feature) {
+  const need = FEATURE_MIN_PROTOCOL[feature] ?? Infinity;
+  const have = instance?.protocolVersion ?? 0;
+  return have >= need;
+}
+
+// One warning per (feature, port) — a busy session must not spam identical lines.
+const _warned = new Set();
+
+/**
+ * Warn exactly once that a feature is unavailable on the connected plugin and the
+ * server is degrading. Writes to stderr (never stdout — stdout is the MCP channel).
+ * @returns {boolean} true if a warning was emitted this call, false if deduped.
+ */
+export function warnOnMissing(feature, instance) {
+  const port = instance?.port ?? "?";
+  const key = `${feature}@${port}`;
+  if (_warned.has(key)) return false;
+  _warned.add(key);
+  const detail = `plugin ${instance?.pluginVersion ?? "unknown"}, protocol ${instance?.protocolVersion ?? "none"}`;
+  console.error(
+    `[AB-UMCP] Connected Unity plugin does not support "${feature}" (${detail}). ` +
+    `Degrading gracefully — update the plugin to remove this warning.`,
+  );
+  return true;
+}
+
+/** Reset the warn-dedupe cache (test hook; also call after a reconnect). */
+export function resetWarnings() {
+  _warned.clear();
+}
+
+/**
+ * Reactive safety net: true when a bridge result is the plugin's "route does not
+ * exist" signal — the `{error:"Unknown API endpoint"}` body (bare or queue-wrapped)
+ * or an HTTP-404 error string. Lets the server fall back even when `protocolVersion`
+ * was never captured (e.g. a registry-sourced instance) or is misreported.
+ */
+export function isRouteUnsupportedError(result) {
+  const RE = /unknown api endpoint|http 404\b|\b404 not found\b/i;
+  if (result == null) return false;
+  if (typeof result === "string") return RE.test(result);
+  if (typeof result === "object") {
+    if (typeof result.error === "string" && RE.test(result.error)) return true;
+    if (result.data && typeof result.data === "object" &&
+        typeof result.data.error === "string" && RE.test(result.data.error)) return true;
+  }
+  return false;
+}
+
+/**
+ * Call component/batch-wire, degrading to N single component/set-reference calls
+ * when the connected plugin can't do batch-wire. Never throws on the drift case.
+ *
+ * Decision table:
+ *   - protocolVersion present and >= min  → fast path (batch-wire).
+ *   - protocolVersion present and <  min  → known-old: skip the call, degrade.
+ *   - protocolVersion absent (unknown)    → try the fast path; degrade only if the
+ *                                           route comes back unsupported (reactive).
+ *
+ * @param {object} bridge - the unity-editor-bridge module (injected for testability).
+ * @param {object|null} instance - selected Unity instance.
+ * @param {object} params - { references: [ ...set-reference-shaped entries ] }.
+ */
+export async function callBatchWireWithFallback(bridge, instance, params) {
+  const pv = instance?.protocolVersion;
+  const knownUnsupported = typeof pv === "number" && !pluginSupports(instance, "batchWire");
+
+  if (!knownUnsupported) {
+    const result = await bridge.batchWireReferences(params);
+    if (!isRouteUnsupportedError(result)) return result; // fast path (or unknown-peer success)
+    // Peer advertised support (or version unknown) but the route is missing — degrade.
+  }
+
+  warnOnMissing("batchWire", instance);
+  return degradeBatchWire(bridge, params);
+}
+
+/**
+ * Emulate component/batch-wire with one component/set-reference call per entry.
+ * @returns {object} aggregate result flagged `degraded:true`.
+ */
+async function degradeBatchWire(bridge, params) {
+  const refs = Array.isArray(params?.references) ? params.references : [];
+  const results = [];
+  let failed = 0;
+  for (const entry of refs) {
+    const r = await bridge.setComponentReference(entry);
+    if (isRouteUnsupportedError(r) || (r && r.error) || (r && r.success === false)) failed++;
+    results.push(r);
+  }
+  return {
+    degraded: true,
+    mode: "batch-wire→set-reference (plugin lacks component/batch-wire)",
+    total: refs.length,
+    failed,
+    results,
+  };
+}

--- a/src/capabilities.test.js
+++ b/src/capabilities.test.js
@@ -1,0 +1,120 @@
+// Tests for the capability-negotiation / graceful-degrade layer.
+// Run: node --test src/capabilities.test.js   (Node >= 18, zero deps)
+//
+// This suite IS the "prove the mechanism" artifact: it demonstrates that an OLD
+// peer (no protocolVersion) triggers exactly one warning and a clean fall-back to
+// single set-reference calls, with no throw — the ml-agents WarnOnMissing behavior.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROTOCOL_VERSION,
+  FEATURE_MIN_PROTOCOL,
+  pluginSupports,
+  warnOnMissing,
+  resetWarnings,
+  isRouteUnsupportedError,
+  callBatchWireWithFallback,
+} from "./capabilities.js";
+
+test("constants: protocol + feature floor are sane", () => {
+  assert.equal(PROTOCOL_VERSION, 1);
+  assert.equal(FEATURE_MIN_PROTOCOL.batchWire, 1);
+});
+
+test("pluginSupports: new peer yes; old/missing/no-instance/unknown-feature no", () => {
+  assert.equal(pluginSupports({ protocolVersion: 1 }, "batchWire"), true);
+  assert.equal(pluginSupports({ protocolVersion: 2 }, "batchWire"), true);
+  assert.equal(pluginSupports({ protocolVersion: 0 }, "batchWire"), false);
+  assert.equal(pluginSupports({}, "batchWire"), false); // old peer: field absent
+  assert.equal(pluginSupports(null, "batchWire"), false); // no instance
+  assert.equal(pluginSupports({ protocolVersion: 9 }, "nope"), false); // unknown feature
+});
+
+test("warnOnMissing: fires once per feature+port, then dedupes; other port warns", () => {
+  resetWarnings();
+  const inst = { port: 7890, pluginVersion: "2.20.0", protocolVersion: 0 };
+  assert.equal(warnOnMissing("batchWire", inst), true); // first time
+  assert.equal(warnOnMissing("batchWire", inst), false); // deduped
+  assert.equal(warnOnMissing("batchWire", { port: 7892 }), true); // different peer
+});
+
+test("isRouteUnsupportedError: matches bare/queue-wrapped unknown-endpoint + 404; not success", () => {
+  assert.equal(isRouteUnsupportedError({ error: "Unknown API endpoint: component/batch-wire" }), true);
+  assert.equal(isRouteUnsupportedError({ data: { error: "Unknown API endpoint: x" } }), true);
+  assert.equal(isRouteUnsupportedError("HTTP 404 Not Found"), true);
+  assert.equal(isRouteUnsupportedError({ success: true, data: { wired: 3 } }), false);
+  assert.equal(isRouteUnsupportedError({ error: "some unrelated failure" }), false);
+  assert.equal(isRouteUnsupportedError(null), false);
+});
+
+test("degrade (proactive): KNOWN-old peer (protocolVersion 0) → N set-reference, no batch call, no throw", async () => {
+  resetWarnings();
+  let batchCalls = 0;
+  let setRefCalls = 0;
+  const bridge = {
+    batchWireReferences: async () => { batchCalls++; return { success: true }; },
+    setComponentReference: async () => { setRefCalls++; return { success: true }; },
+  };
+  const params = { references: [{ propertyName: "a" }, { propertyName: "b" }, { propertyName: "c" }] };
+
+  const out = await callBatchWireWithFallback(bridge, { port: 7890, protocolVersion: 0 }, params);
+
+  assert.equal(batchCalls, 0, "must not call batch-wire on a known-unsupported peer");
+  assert.equal(setRefCalls, 3, "one set-reference per entry");
+  assert.equal(out.degraded, true);
+  assert.equal(out.total, 3);
+  assert.equal(out.failed, 0);
+});
+
+test("degrade (reactive): peer CLAIMS support but route missing → tries once, falls back, no throw", async () => {
+  resetWarnings();
+  let batchCalls = 0;
+  let setRefCalls = 0;
+  const bridge = {
+    batchWireReferences: async () => { batchCalls++; return { error: "Unknown API endpoint: component/batch-wire" }; },
+    setComponentReference: async () => { setRefCalls++; return { success: true }; },
+  };
+  const params = { references: [{ propertyName: "a" }, { propertyName: "b" }] };
+
+  const out = await callBatchWireWithFallback(bridge, { port: 7890, protocolVersion: 1 }, params);
+
+  assert.equal(batchCalls, 1, "reactive path tries the fast route once");
+  assert.equal(setRefCalls, 2);
+  assert.equal(out.degraded, true);
+});
+
+test("unknown peer (no protocolVersion): tries fast path; keeps it when the route works", async () => {
+  resetWarnings();
+  let batchCalls = 0;
+  let setRefCalls = 0;
+  const bridge = {
+    batchWireReferences: async () => { batchCalls++; return { success: true, wired: 2 }; },
+    setComponentReference: async () => { setRefCalls++; return { success: true }; },
+  };
+  const params = { references: [{ propertyName: "a" }, { propertyName: "b" }] };
+
+  const out = await callBatchWireWithFallback(bridge, { port: 7890 }, params); // field absent
+
+  assert.equal(batchCalls, 1, "unknown peer must NOT be pre-degraded");
+  assert.equal(setRefCalls, 0);
+  assert.equal(out.degraded, undefined, "fast path returns the bridge result as-is");
+  assert.equal(out.success, true);
+});
+
+test("fast path: KNOWN-new peer → batch-wire used, no fallback", async () => {
+  resetWarnings();
+  let batchCalls = 0;
+  let setRefCalls = 0;
+  const bridge = {
+    batchWireReferences: async () => { batchCalls++; return { success: true, wired: 2 }; },
+    setComponentReference: async () => { setRefCalls++; return { success: true }; },
+  };
+  const params = { references: [{ propertyName: "a" }, { propertyName: "b" }] };
+
+  const out = await callBatchWireWithFallback(bridge, { port: 7890, protocolVersion: 1 }, params);
+
+  assert.equal(batchCalls, 1);
+  assert.equal(setRefCalls, 0);
+  assert.equal(out.success, true);
+});

--- a/src/instance-discovery.js
+++ b/src/instance-discovery.js
@@ -313,6 +313,8 @@ export async function discoverInstances() {
             unityVersion: info?.unityVersion || "",
             isClone: info?.isClone || false,
             cloneIndex: info?.cloneIndex ?? -1,
+            protocolVersion: info?.protocolVersion ?? null,
+            pluginVersion: info?.pluginVersion || null,
             alive: true,
             source: "portscan",
           };
@@ -351,6 +353,8 @@ export async function autoSelectInstance() {
         unityVersion: info?.unityVersion || "",
         isClone: false,
         cloneIndex: -1,
+        protocolVersion: info?.protocolVersion ?? null,
+        pluginVersion: info?.pluginVersion || null,
         alive: true,
         source: "default",
       };
@@ -494,6 +498,9 @@ async function getInstanceInfo(port) {
       unityVersion: data.unityVersion || data.version || null,
       isClone: data.isClone || false,
       cloneIndex: data.cloneIndex ?? -1,
+      // Capability handshake (server↔plugin drift): absent on pre-handshake plugins.
+      protocolVersion: data.protocolVersion ?? null,
+      pluginVersion: data.pluginVersion || null,
     };
   } catch {
     return null;

--- a/src/tools/editor-tools.js
+++ b/src/tools/editor-tools.js
@@ -1,6 +1,9 @@
 ﻿// AnkleBreaker Unity MCP â€” Tool definitions for Unity Editor operations (via HTTP bridge)
 import * as bridge from "../unity-editor-bridge.js";
 
+import { callBatchWireWithFallback } from "../capabilities.js";
+import { getSelectedInstance } from "../instance-discovery.js";
+
 export const editorTools = [
   // â”€â”€â”€ Connection â”€â”€â”€
   {
@@ -255,7 +258,10 @@ export const editorTools = [
       },
       required: ["references"],
     },
-    handler: async (params) => JSON.stringify(await bridge.batchWireReferences(params), null, 2),
+    // Negotiated capability: fall back to N single set-reference calls when the
+    // connected plugin predates component/batch-wire (see src/capabilities.js).
+    handler: async (params) =>
+      JSON.stringify(await callBatchWireWithFallback(bridge, getSelectedInstance(), params), null, 2),
   },
   {
     name: "unity_component_get_referenceable",


### PR DESCRIPTION
One-int `protocolVersion` handshake so the server survives version drift with the plugin (they ship on separate release trains).

Before using `component/batch-wire`, the server checks whether the connected plugin advertises a new-enough `protocolVersion`:

- new enough -> fast path (one batch call)
- too old -> one warning + graceful fallback to N single `component/set-reference` calls
- version unknown -> try the fast path, fall back only if the route 404s

Pattern adapted from Unity ML-Agents' `UnityRLCapabilities`. One-sided provider check, gated on a single monotonic int (not a bool catalog that would rot). Self-contained; no behavior change when server and plugin versions match.

Adds `src/capabilities.js` + tests, a small `protocolVersion` capture in `src/instance-discovery.js`, and routes the batch-wire tool handler through the fallback.
