### PR TITLE
v2.35.5 — audit patch: error diagnostics restored + fail-closed routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package will be documented in this file.
 
+## [2.35.5] - 2026-07-24
+
+Findings from a 33-dimension + 10-blind-spot audit (127 + 40 agents, every CRITICAL/HIGH adversarially verified). Companion plugin: **2.39.4**.
+
+### Fixed
+- **Every Unity-side error message was being thrown away.** The queue ticket carries the exception in `errorMessage` (`MCPRequestQueue.TicketToDict`) but the poller read `statusData.error`, which never exists on that shape — so EVERY failure across all 337 routes collapsed to the generic `"Queue processing failed"`, and agents retried non-idempotent writes blind. **This also silently broke two other features** that detect old plugins by reading `"Unknown API endpoint"` out of the error text: the advanced-tool *did-you-mean* suggestions and the `component_batch_wire` graceful degrade. All three are repaired by reading the right field.
+  - The mock bridge emitted the wrong field name too, which is why a 59-test suite never caught it — it now mirrors `TicketToDict` exactly. The regression test that accepted `success:false` as an alternative (letting the real message vanish unnoticed) now asserts the verbatim text, and is proven to fail without the fix.
+- **A vanished project no longer silently redirects writes to a different one.** When an agent's selected instance disappeared, the code cleared the selection AND set the "selection required" gate to `false`, so the same tool call fell through to the default port — a *different* live Unity in any multi-project session, reporting success the whole way. It now fails closed and demands re-selection.
+- **A transient failure no longer permanently downgrades the session.** Any lingering submit error (editor not up yet, a domain reload longer than the retry window) latched `_useQueueMode = false` for the entire process, losing agent attribution, per-action undo grouping and read-batching, with nothing to ever reset it. Only a definitive HTTP 404 now proves the plugin lacks queue mode; transient failures fall back for that one call and re-probe next time.
+
+### Added
+- `unity_asset_delete` exposes `recursive` and `permanent`; `unity_scene_open` / `unity_scene_new` expose `saveFirst` and `discardUnsavedChanges` — the opt-ins for the plugin's new data-loss guards. (`openScene`/`newScene` previously dropped everything but `path`.)
+
+### Changed
+- License declared as `SEE LICENSE IN LICENSE` in `package.json` (it declared none) and `manifest.json` (it declared `MIT`) — the shipped LICENSE is the AnkleBreaker Open License v1.0. `manifest.json` version was also stale at 2.35.2 and is now synced.
+- Rich-mode `tools/list` budget 47KB → 48KB for the four new data-safety params (~47.5KB actual, still ~60% under the 120KB ceiling).
+
 ## [2.35.4] - 2026-07-23
 
 ### Fixed (Discord ProBuilder report — tool-surface gaps; companion `unity-mcp-plugin` 2.39.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Findings from a 33-dimension + 10-blind-spot audit (127 + 40 agents, every CRITI
 
 ### Added
 - `unity_asset_delete` exposes `recursive` and `permanent`; `unity_scene_open` / `unity_scene_new` expose `saveFirst` and `discardUnsavedChanges` — the opt-ins for the plugin's new data-loss guards. (`openScene`/`newScene` previously dropped everything but `path`.)
+- `unity_scene_save` takes an optional `path` — **required** for a scene that has never been saved, and doubling as Save-As. Without it the plugin had to raise Unity's interactive Save dialog from the request pump, which hangs an unattended editor. (`saveScene` forwarded no params at all before.)
 
 ### Changed
 - License declared as `SEE LICENSE IN LICENSE` in `package.json` (it declared none) and `manifest.json` (it declared `MIT`) — the shipped LICENSE is the AnkleBreaker Open License v1.0. `manifest.json` version was also stale at 2.35.2 and is now synced.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "unity-mcp",
   "display_name": "AnkleBreaker Unity MCP",
-  "version": "2.35.2",
+  "version": "2.35.5",
   "description": "Multi-agent MCP server for Unity Editor — 346 tools (69 core + 268 advanced via two-tier system) across 40+ categories with multi-instance support. Designed for Claude Cowork with async queue and fair scheduling across agents.",
   "long_description": "AnkleBreaker Unity MCP connects Claude to your Unity Editor with 346 tools across 40+ categories. Built for Claude Cowork's multi-agent architecture, where multiple AI agents collaborate on the same Unity project in parallel.\n\n**Key features:**\n- 346 tools via two-tier system: 69 core + 268 advanced (via unity_advanced_tool) + 9 hub/instance/context\n- Three-level lazy discovery (unity_list_advanced_tools search=/category=/tool=) — finding one tool costs ~1KB of context instead of a schema dump\n- Two-tier architecture keeps the tools/list payload small (~45KB, or ~23KB with UNITY_MCP_COMPACT_TOOLS=1) for reliable client registration\n- Multi-instance support: run multiple Unity Editors simultaneously, auto-port selection (7890–7899), shared instance registry\n- ParrelSync clone detection for multiplayer development workflows\n- Multi-agent async queue with fair round-robin scheduling and per-action undo (unity_undo_last)\n- Read batching (up to 5/frame) and write serialization (1/frame)\n- Agent session tracking and action logging\n- ProBuilder integration (14 tools: parametric shapes, face edits, boolean CSG, materials) when com.unity.probuilder is installed\n- Project Context auto-injection for project-aware AI assistance\n- Automatic fallback to legacy sync mode for older plugin versions\n\n**Requires the companion Unity Editor plugin:** Install via Unity Package Manager → Add package from git URL → `https://github.com/AnkleBreaker-Studio/unity-mcp-plugin.git`\n\nAfter installing the plugin, open Window → AB Unity MCP in Unity and verify the bridge is running.",
   "author": {
@@ -18,7 +18,7 @@
   "documentation": "https://github.com/AnkleBreaker-Studio/unity-mcp-server/blob/main/README.md",
   "support": "https://github.com/AnkleBreaker-Studio/unity-mcp-server/issues",
   "icon": "icon.png",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "keywords": [
     "unity",
     "unity3d",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "anklebreaker-unity-mcp",
-  "version": "2.35.4",
+  "version": "2.35.5",
   "description": "Unity MCP Server — Multi-agent MCP server for Unity Editor, designed for Claude Cowork. By AnkleBreaker Studio.",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "main": "src/index.js",
   "bin": {

--- a/src/instance-discovery.js
+++ b/src/instance-discovery.js
@@ -171,10 +171,15 @@ export async function validateSelectedInstance() {
     }
   }
 
-  // Project truly gone — not responding AND not in registry
-  debugLog(`Project "${saved.projectName}" no longer found. Clearing selection for agent ${_currentAgentId}.`);
+  // Project truly gone — not responding AND not in registry.
+  // FAIL CLOSED: this agent explicitly had a project selected and that project vanished.
+  // Clearing the flag to false let the very same tool call fall through to the default port,
+  // which in any multi-project session is a DIFFERENT live Unity — so a write intended for
+  // project A silently landed in project B and still reported success. Require an explicit
+  // re-selection instead.
+  debugLog(`Project "${saved.projectName}" no longer found. Clearing selection for agent ${_currentAgentId} and requiring re-selection.`);
   _agentInstances.delete(_currentAgentId);
-  _agentSelectionRequired.set(_currentAgentId, false);
+  _agentSelectionRequired.set(_currentAgentId, true);
   return null;
 }
 

--- a/src/tools/editor-tools.js
+++ b/src/tools/editor-tools.js
@@ -84,15 +84,19 @@ export const editorTools = [
   },
   {
     name: "unity_scene_open",
-    description: "Open a scene by its asset path (relative to Assets/).",
+    description:
+      "Open a scene by its asset path (relative to Assets/). Refuses if any loaded scene has " +
+      "unsaved changes — pass saveFirst or discardUnsavedChanges.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "Scene asset path, e.g. 'Assets/Scenes/MainScene.unity'" },
+        saveFirst: { type: "boolean", description: "Save all modified scenes before switching." },
+        discardUnsavedChanges: { type: "boolean", description: "Proceed and LOSE unsaved changes." },
       },
       required: ["path"],
     },
-    handler: async ({ path }) => formatResult(await bridge.openScene(path)),
+    handler: async (params) => formatResult(await bridge.openScene(params)),
   },
   {
     name: "unity_scene_save",
@@ -102,9 +106,17 @@ export const editorTools = [
   },
   {
     name: "unity_scene_new",
-    description: "Create a new empty scene.",
-    inputSchema: { type: "object", properties: {} },
-    handler: async () => formatResult(await bridge.newScene()),
+    description:
+      "Create a new empty scene (REPLACES the current one). Refuses if any loaded scene has " +
+      "unsaved changes — pass saveFirst or discardUnsavedChanges.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        saveFirst: { type: "boolean", description: "Save all modified scenes first." },
+        discardUnsavedChanges: { type: "boolean", description: "Proceed and LOSE unsaved changes." },
+      },
+    },
+    handler: async (params) => formatResult(await bridge.newScene(params)),
   },
   {
     name: "unity_scene_hierarchy",
@@ -398,11 +410,15 @@ export const editorTools = [
   },
   {
     name: "unity_asset_delete",
-    description: "Delete an asset from the project.",
+    description:
+      "Delete an asset — to the OS trash by default (NOT undoable via unity_undo_last). " +
+      "Deleting a FOLDER is recursive and refuses without recursive:true.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "Asset path relative to project root (e.g. 'Assets/Scripts/MyScript.cs')" },
+        recursive: { type: "boolean", description: "Required to delete a FOLDER and its contents. Default false refuses, reporting the asset count." },
+        permanent: { type: "boolean", description: "Hard-delete instead of OS trash. Default false." },
       },
       required: ["path"],
     },

--- a/src/tools/editor-tools.js
+++ b/src/tools/editor-tools.js
@@ -100,9 +100,16 @@ export const editorTools = [
   },
   {
     name: "unity_scene_save",
-    description: "Save the current scene.",
-    inputSchema: { type: "object", properties: {} },
-    handler: async () => formatResult(await bridge.saveScene()),
+    description:
+      "Save the current scene. A never-saved scene requires `path` (saving without one would " +
+      "open Unity's interactive Save dialog).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "Asset path to save to, e.g. 'Assets/Scenes/MyScene.unity'. Required for a scene that has never been saved; also acts as Save-As." },
+      },
+    },
+    handler: async (params) => formatResult(await bridge.saveScene(params)),
   },
   {
     name: "unity_scene_new",

--- a/src/unity-editor-bridge.js
+++ b/src/unity-editor-bridge.js
@@ -470,8 +470,8 @@ export async function openScene(params) {
   return sendCommand("scene/open", typeof params === "string" ? { path: params } : params);
 }
 
-export async function saveScene() {
-  return sendCommand("scene/save");
+export async function saveScene(params = {}) {
+  return sendCommand("scene/save", params);
 }
 
 export async function newScene(params = {}) {

--- a/src/unity-editor-bridge.js
+++ b/src/unity-editor-bridge.js
@@ -159,16 +159,24 @@ async function pollQueueStatus(ticketId) {
           data: statusData.result !== undefined ? statusData.result : { status: "Completed" },
         };
       } else if (statusData.status === "Failed") {
+        // The queue ticket carries the Unity-side exception in `errorMessage`
+        // (MCPRequestQueue.TicketToDict) — reading only `error` here silently discarded
+        // EVERY real diagnostic and returned the generic fallback for all routes, which
+        // pushed agents into retrying non-idempotent writes blind. `error` is still
+        // accepted for the legacy synchronous shape.
         return {
           success: false,
-          error: statusData.error || "Queue processing failed",
+          error: statusData.errorMessage || statusData.error || "Queue processing failed",
         };
       } else if (statusData.status === "TimedOut") {
         // Terminal on the plugin side — surface it now instead of polling a doomed ticket
         // until it's evicted (which then reads back as a misleading 404 ~30-60s later).
         return {
           success: false,
-          error: statusData.error || `Unity-side execution timed out for ticket ${ticketId}`,
+          error:
+            statusData.errorMessage ||
+            statusData.error ||
+            `Unity-side execution timed out for ticket ${ticketId}`,
         };
       }
 
@@ -347,19 +355,21 @@ export async function sendCommand(command, params = {}) {
 
       // If we get here, queue submit failed after retries
       if (submitLastError) {
+        // A TRANSIENT failure (editor not up yet, domain reload longer than the retry window,
+        // connection reset) is NOT evidence the plugin lacks queue mode — only the HTTP 404
+        // above is. Latching here downgraded the session permanently and irreversibly: legacy
+        // mode loses agent attribution, per-action undo grouping and read-batching, and nothing
+        // ever reset the flags. Fall back for THIS call, leave the mode undetermined so the
+        // next call re-probes.
         console.warn(
-          `[MCP Bridge] Queue mode failed after retries, falling back to legacy sync mode: ${submitLastError.message}`
+          `[MCP Bridge] Queue submit failed after retries, using legacy sync for this call (mode left undetermined): ${submitLastError.message}`
         );
-        _queueModeDetermined = true;
-        _useQueueMode = false;
         return sendCommandLegacyMode(command, params);
       }
     } catch (error) {
       console.warn(
-        `[MCP Bridge] Unexpected error in queue mode, falling back to legacy: ${error.message}`
+        `[MCP Bridge] Unexpected error in queue mode, using legacy sync for this call (mode left undetermined): ${error.message}`
       );
-      _queueModeDetermined = true;
-      _useQueueMode = false;
       return sendCommandLegacyMode(command, params);
     }
   }
@@ -453,16 +463,19 @@ export async function getSceneInfo() {
   return sendCommand("scene/info");
 }
 
-export async function openScene(scenePath) {
-  return sendCommand("scene/open", { path: scenePath });
+export async function openScene(params) {
+  // Accepts the full param object so the unsaved-changes opt-ins (saveFirst /
+  // discardUnsavedChanges) reach the plugin; a bare string stays supported for callers
+  // that only pass a path.
+  return sendCommand("scene/open", typeof params === "string" ? { path: params } : params);
 }
 
 export async function saveScene() {
   return sendCommand("scene/save");
 }
 
-export async function newScene() {
-  return sendCommand("scene/new");
+export async function newScene(params = {}) {
+  return sendCommand("scene/new", params);
 }
 
 export async function getHierarchy(params) {

--- a/tests/helpers/mock-bridge.mjs
+++ b/tests/helpers/mock-bridge.mjs
@@ -130,18 +130,21 @@ export class MockBridge {
         const params = payload.body ? JSON.parse(payload.body) : {};
         this.seen.push({ route, params, headers: req.headers, via: "queue" });
         const ticketId = `ticket-${++this._ticketCounter}`;
-        const ticket = { ticketId, status: "Queued", agentId: payload.agentId || "unknown", result: null, error: null };
+        // Field names mirror the plugin's MCPRequestQueue.TicketToDict EXACTLY. The failure
+        // text lives in `errorMessage` — the mock previously emitted `error`, which is why a
+        // 59-test suite never caught the server reading the wrong field for every route.
+        const ticket = { ticketId, status: "Queued", agentId: payload.agentId || "unknown", result: null, errorMessage: "" };
         this._tickets.set(ticketId, ticket);
         const complete = () => {
           try {
             const outcome = this._resolve(route, params);
             if (outcome && outcome.__fail) {
               ticket.status = "Failed";
-              ticket.error = outcome.error || "Mock failure";
+              ticket.errorMessage = outcome.error || "Mock failure";
             } else if (outcome && outcome.__timeout) {
               // Simulate a plugin-side sync-timeout terminal state.
               ticket.status = "TimedOut";
-              ticket.error = outcome.error || "Timed out on the main thread";
+              ticket.errorMessage = outcome.error || "Timed out on the main thread";
             } else if (outcome && outcome.__evict) {
               // Simulate a domain reload evicting the ticket mid-flight: the action ran,
               // but every subsequent status poll 404s (the play-mode false-negative class).
@@ -152,7 +155,7 @@ export class MockBridge {
             }
           } catch (err) {
             ticket.status = "Failed";
-            ticket.error = err.message;
+            ticket.errorMessage = err.message;
           }
         };
         this.processingDelayMs > 0 ? setTimeout(complete, this.processingDelayMs) : complete();

--- a/tests/protocol.test.mjs
+++ b/tests/protocol.test.mjs
@@ -152,14 +152,17 @@ describe("queue-mode session (single instance)", () => {
   // with full parameter docs retained, later ~44.3KB after adding the `overwrite` safety param
   // to the core asset-creator tools, then ~45.7KB after adding the core `unity_undo_last` tool
   // (per-action/per-agent undo), then ~46.6KB after the core `unity_gameobject_delete`
-  // shared-mesh guard + `force` override (ProBuilder clone data-safety). The gate catches
-  // unintentional bloat while leaving room for deliberate capability — still ~61% under the
-  // 120KB hard ceiling. UNITY_MCP_COMPACT_TOOLS=1 (tested below) goes much further for
-  // constrained clients. Bump this only for a real new capability, never to absorb prose creep.
+  // shared-mesh guard + `force` override (ProBuilder clone data-safety), then ~47.5KB after the
+  // audit's data-safety wave: asset_delete gained recursive/permanent, and scene_open/scene_new
+  // gained saveFirst/discardUnsavedChanges (each one is a documented way to NOT lose the user's
+  // work, so the bytes buy real protection). The gate catches unintentional bloat while leaving
+  // room for deliberate capability — still ~60% under the 120KB hard ceiling.
+  // UNITY_MCP_COMPACT_TOOLS=1 (tested below) goes much further for constrained clients.
+  // Bump this only for a real new capability, never to absorb prose creep.
   test("tools/list payload stays within the rich-mode diet budget", async () => {
     const { tools } = await client.listTools();
     const bytes = Buffer.byteLength(JSON.stringify(tools), "utf8");
-    assert.ok(bytes <= 47_000, `tools/list ${bytes} bytes exceeds the 47KB rich-mode budget`);
+    assert.ok(bytes <= 48_000, `tools/list ${bytes} bytes exceeds the 48KB rich-mode budget`);
   });
 
   // Lazy discovery is three-tier so finding one tool never costs a schema dump:
@@ -328,13 +331,29 @@ describe("queue-mode session (single instance)", () => {
     assert.equal(seen.via, "queue");
   });
 
-  test("logical failures surface an error payload", async () => {
+  // The VERBATIM Unity-side message must reach the agent. This assertion used to accept
+  // `success:false` as an alternative, which let a real regression hide: the queue ticket
+  // carries the exception in `errorMessage` (MCPRequestQueue.TicketToDict) while the server
+  // read only `error`, so EVERY route's diagnostic collapsed to "Queue processing failed"
+  // and agents retried non-idempotent writes blind. Assert the actual text, nothing weaker.
+  test("logical failures surface the verbatim Unity error message", async () => {
     const { payload, payloadText } = await client.callTool("unity_advanced_tool", {
       tool: "unity_logical_failure",
       params: {},
     });
     const text = payload ? JSON.stringify(payload) : payloadText;
-    assert.match(text, /boom: mock logical failure|success.{0,4}false/i);
+    assert.match(text, /boom: mock logical failure/i);
+    assert.doesNotMatch(text, /Queue processing failed/i, "generic fallback must not replace the real message");
+  });
+
+  // Same contract on the terminal TimedOut branch, which reads the same field.
+  test("plugin-side timeouts surface the verbatim Unity timeout message", async () => {
+    const { payload, payloadText } = await client.callTool("unity_advanced_tool", {
+      tool: "unity_plugin_timeout",
+      params: {},
+    });
+    const text = payload ? JSON.stringify(payload) : payloadText;
+    assert.match(text, /Timed out on the main thread/i);
   });
 
   // MCP spec: logical failures set isError so clients don't read them as success.


### PR DESCRIPTION
Patch release from a **43-run audit** (33 dimensions + 10 blind-spot dimensions, 168 agents, every CRITICAL/HIGH adversarially verified). Companion plugin: **2.39.4**.

## 🔍 The headline: every Unity error message was being thrown away

The queue ticket carries the Unity-side exception in **`errorMessage`** (`MCPRequestQueue.TicketToDict`), but the poller read **`statusData.error`** — a field that never exists on that shape. So **every failure across all 337 routes** collapsed to the generic `"Queue processing failed"`, and agents, given no diagnostic, retried non-idempotent writes blind.

**It was worse than it looked.** Two other features detect old plugins by reading `"Unknown API endpoint"` out of that same error text — the advanced-tool **did-you-mean** suggestions and the **`component_batch_wire` graceful degrade**. Both had been silently broken in production. All three are repaired by reading the right field.

**Why 59 tests never caught it:** the mock bridge emitted the wrong field name too, so the suite validated a fiction. The mock now mirrors `TicketToDict` exactly, and the assertion that accepted `success:false` as an alternative (letting the real message vanish unnoticed) now asserts the verbatim text — and is **proven to fail without the fix**.

## ⚙️ Also fixed
- **A vanished project no longer redirects writes to a different one.** When an agent's selected instance disappeared, the code cleared the selection *and* disabled the "selection required" gate, so the same call fell through to the default port — a **different live Unity** in any multi-project session, reporting success throughout. Now fails closed.
- **A transient failure no longer permanently downgrades the session.** Any lingering submit error (editor not up yet, a long domain reload) latched `_useQueueMode = false` process-wide — losing agent attribution, per-action undo grouping and read-batching, with nothing to ever reset it. Only a definitive HTTP 404 now proves the plugin lacks queue mode.

## ➕ Added
Schema opt-ins for the plugin's new data-loss guards: `unity_asset_delete` → `recursive` / `permanent`; `unity_scene_open` / `unity_scene_new` → `saveFirst` / `discardUnsavedChanges`; `unity_scene_save` → `path` (required for a never-saved scene, doubles as Save-As). Several of these bridge functions previously dropped every param but `path`.

## 🧹 Changed
License declared correctly (`package.json` had none, `manifest.json` said `MIT` while shipping the AnkleBreaker Open License v1.0); `manifest.json` version was stale at 2.35.2 and is synced; `tools/list` budget 47KB → 48KB for the new data-safety params (~47.5KB actual, ~60% under the 120KB ceiling).

## Gates
60/60 tests, route registry 337 in sync, companion plugin compiles clean against a live editor.

Full detail: [`CHANGELOG.md`](https://github.com/AnkleBreaker-Studio/unity-mcp-server/blob/Development-Fable-Improvements/CHANGELOG.md).