### PR TITLE
Fix flaky batch-wire degrade assertion (green CI on node 22 / ubuntu)

### DIFF
--- a/tests/protocol.test.mjs
+++ b/tests/protocol.test.mjs
@@ -429,7 +429,22 @@ describe("queue-mode session (single instance)", () => {
     assert.equal(isError, false);
     const singles = bridge.seen.filter((r) => r.route === "component/set-reference");
     assert.equal(singles.length, 2, "each entry executed as its own set-reference call");
-    assert.deepEqual(singles.map((r) => r.params.propertyName), ["panelA", "panelB"]);
+    // The degrade fires the calls CONCURRENTLY (Promise.all) to bound wall-clock by the
+    // slowest call rather than their sum. Promise.all guarantees RESULT order, not network
+    // ARRIVAL order — so asserting the order the mock happened to receive them was testing
+    // a property the implementation never promised, and it duly flipped on a faster runner.
+    // Assert the set that arrived, then the guarantee that actually matters:
+    // results[i] still corresponds to references[i].
+    assert.deepEqual(
+      singles.map((r) => r.params.propertyName).sort(),
+      ["panelA", "panelB"],
+      "both entries were wired (arrival order is not guaranteed — the calls are concurrent)"
+    );
+    assert.deepEqual(
+      payload.results.map((r) => (r.data ? r.data.wired : r.wired)),
+      ["panelA", "panelB"],
+      "results stay aligned with the input references order"
+    );
   });
 
   test("degraded batch-wire reports failure when an entry fails via the legacy error envelope", async () => {


### PR DESCRIPTION
`main` CI went red on **node 22 / ubuntu** only (the other three matrix jobs passed, and a re-run reproduced it — so not a transient flake).

**Root cause: the test asserted a guarantee the code never made.** The batch-wire degrade deliberately fires its `set-reference` calls **concurrently** via `Promise.all` (to bound wall-clock by the slowest call rather than their sum). `Promise.all` preserves **result** order — it says nothing about the order the requests reach the server. The test compared the order the mock *received* them, which held by luck until the timing shifted.

The source comment states the real contract: *"Promise.all preserves order, so results[i] still matches references[i]."* The test now checks exactly that:
- the arrived **set** (order-independent) — both entries were wired
- `results[i]` aligns with `references[i]` — read through the bridge's `{success, data}` envelope

This is strictly stronger than before: the old assertion never actually verified the order-preservation claim.

Verified across 8 consecutive local runs, 60/60 each.