### PR TITLE
fix(discovery): validate bridge identity before adopting a port

### DIFF
--- a/src/instance-discovery.js
+++ b/src/instance-discovery.js
@@ -463,6 +463,20 @@ function readRegistryFile() {
  * @param {number} port
  * @returns {boolean} True if the instance is alive.
  */
+// Fields the Unity MCP plugin's /api/ping is known to return. The plugin has shipped
+// projectPath since v2.21.1 specifically "enabling the MCP server to validate instance
+// identity"; older plugins still return projectName + unityVersion. A responder that
+// carries none of these is some other local service that happens to answer 200 on this
+// path — never adopt it as a Unity instance.
+const BRIDGE_IDENTITY_FIELDS = [
+  "projectName",
+  "project",
+  "projectPath",
+  "unityVersion",
+  "version",
+  "pluginVersion",
+];
+
 async function pingInstance(port) {
   try {
     const url = `http://${CONFIG.editorBridgeHost}:${port}/api/ping`;
@@ -470,7 +484,18 @@ async function pingInstance(port) {
       method: "GET",
       signal: AbortSignal.timeout(1500), // Short timeout for discovery
     });
-    return response.ok;
+    if (!response.ok) return false;
+
+    // A 200 is not proof this is our bridge. The port scan sweeps a fixed range, so any
+    // unrelated local server answering on /api/ping would otherwise be listed as an
+    // instance with empty metadata ("Unknown (port N)") and become a routable target.
+    // Non-JSON bodies throw out of .json() and land in the catch below.
+    const data = await response.json();
+    if (!data || typeof data !== "object") return false;
+
+    return BRIDGE_IDENTITY_FIELDS.some(
+      (field) => data[field] !== undefined && data[field] !== null && data[field] !== ""
+    );
   } catch {
     return false;
   }

--- a/src/instance-discovery.js
+++ b/src/instance-discovery.js
@@ -458,11 +458,6 @@ function readRegistryFile() {
   }
 }
 
-/**
- * Ping a Unity instance at a specific port (fast timeout for discovery).
- * @param {number} port
- * @returns {boolean} True if the instance is alive.
- */
 // Fields the Unity MCP plugin's /api/ping is known to return. The plugin has shipped
 // projectPath since v2.21.1 specifically "enabling the MCP server to validate instance
 // identity"; older plugins still return projectName + unityVersion. A responder that
@@ -477,6 +472,26 @@ const BRIDGE_IDENTITY_FIELDS = [
   "pluginVersion",
 ];
 
+/**
+ * True when a /api/ping body carries at least one field identifying it as this plugin's
+ * bridge. A 200 alone is not proof: both discovery paths reach ports we do not control.
+ * The port scan sweeps a fixed range, and a registry entry's port may have been taken
+ * over by another local service after the Editor that claimed it died.
+ * @param {any} data - Parsed /api/ping response body.
+ * @returns {boolean}
+ */
+function isBridgeIdentity(data) {
+  if (!data || typeof data !== "object") return false;
+  return BRIDGE_IDENTITY_FIELDS.some(
+    (field) => data[field] !== undefined && data[field] !== null && data[field] !== ""
+  );
+}
+
+/**
+ * Ping a Unity instance at a specific port (fast timeout for discovery).
+ * @param {number} port
+ * @returns {boolean} True if a Unity MCP bridge answered.
+ */
 async function pingInstance(port) {
   try {
     const url = `http://${CONFIG.editorBridgeHost}:${port}/api/ping`;
@@ -486,16 +501,10 @@ async function pingInstance(port) {
     });
     if (!response.ok) return false;
 
-    // A 200 is not proof this is our bridge. The port scan sweeps a fixed range, so any
-    // unrelated local server answering on /api/ping would otherwise be listed as an
-    // instance with empty metadata ("Unknown (port N)") and become a routable target.
+    // Without this, any unrelated local server answering on /api/ping is listed as an
+    // instance with empty metadata ("Unknown (port N)") and becomes a routable target.
     // Non-JSON bodies throw out of .json() and land in the catch below.
-    const data = await response.json();
-    if (!data || typeof data !== "object") return false;
-
-    return BRIDGE_IDENTITY_FIELDS.some(
-      (field) => data[field] !== undefined && data[field] !== null && data[field] !== ""
-    );
+    return isBridgeIdentity(await response.json());
   } catch {
     return false;
   }
@@ -517,6 +526,13 @@ async function getInstanceInfo(port) {
     if (!response.ok) return null;
 
     const data = await response.json();
+
+    // Registry validation calls this directly (no pingInstance gate on that path). A stale
+    // entry whose port was taken over by another local service would otherwise be revived
+    // as "alive" while carrying the DEAD project's name and path from the spread entry —
+    // a mis-route that looks legitimate in unity_list_instances.
+    if (!isBridgeIdentity(data)) return null;
+
     return {
       projectName: data.projectName || data.project || null,
       projectPath: data.projectPath || null,


### PR DESCRIPTION
## Problem

Instance discovery treats **any** HTTP 200 on `/api/ping` as a Unity MCP bridge. It never looks at the response body, so any unrelated local process listening on a scanned port is adopted as an Editor instance and becomes a routable target for commands.

`pingInstance()` was:

```js
const response = await fetch(url, { method: "GET", signal: AbortSignal.timeout(1500) });
return response.ok;
```

Two paths are affected, and the second is the dangerous one.

**1. Port scan (`discoverInstances`, step 2).** The scan sweeps a fixed range (`portRangeStart`..`portRangeEnd`, default 7890-7899). An unrelated local service answering there is listed as `"Unknown (port N)"` with empty metadata. Visible, at least.

**2. Registry validation (`discoverInstances`, step 1).** This path calls `getInstanceInfo()` directly and only drops the entry when it returns `null` - which happens on a non-200 or a throw, not on an unrecognised body. So:

- Editor for `ProjectA` registers on port 7892 and writes the registry entry.
- Editor crashes; `OnDisable` never fires; the entry goes stale.
- An unrelated local process later binds 7892.
- Discovery validates the stale entry, gets a 200, and marks it `alive: true` - while spreading `...entry`, so it keeps **ProjectA's name and path**.

The result is an instance that looks completely legitimate in `unity_list_instances` while commands route into a foreign process. There is no visible symptom.

## Fix

Validate identity from the ping body before adopting a port. The plugin already ships the data for exactly this purpose - from the plugin changelog, v2.21.1:

> Enriched ping response - the `/api/ping` endpoint now returns `projectPath` alongside the existing `projectName`, **enabling the MCP server to validate instance identity by both name and path**.

The server side of that was never wired up. This adds it.

A shared `isBridgeIdentity()` predicate requires the ping body to carry at least one known bridge field (`projectName`, `project`, `projectPath`, `unityVersion`, `version`, `pluginVersion`), and both discovery paths now use it - `pingInstance()` for the port scan, `getInstanceInfo()` for registry validation.

## Compatibility

No behaviour change for real bridges of any vintage. Pre-handshake plugins still return `projectName` + `unityVersion`, so they pass. No config, default port, or protocol change.

## Verification

Project suite, unmodified:

```
ℹ tests 60
ℹ pass 60
ℹ fail 0
```

Plus a targeted harness with three loopback stubs - a bridge-shaped responder on 18891, a "squatter" on 18892 named by a stale registry entry as `DeadProject`, and an unrelated JSON responder on 18893:

```
discovered: [{"p":18891,"n":"LiveProject"}]
port-scan foreign rejected      : true
stale-registry squatter rejected: true
real bridge still found         : true
```

Against the pre-fix code the same harness accepts both the bridge and the impostors, confirming the check discriminates rather than passing everything.

## Commits

- `fix(discovery): validate bridge identity before adopting a scanned port` - port-scan path
- `fix(discovery): gate registry validation on bridge identity too` - registry path, extracts the shared predicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
